### PR TITLE
fix(deployment): remove repeated values in readinessProbe

### DIFF
--- a/charts/windmill/templates/deploy_windmill.yaml
+++ b/charts/windmill/templates/deploy_windmill.yaml
@@ -45,8 +45,6 @@ spec:
         - containerPort: 8000
         - containerPort: 8001
         readinessProbe:
-          initialDelaySeconds: 1
-          periodSeconds: 2
           timeoutSeconds: 1
           successThreshold: 1
           failureThreshold: 1


### PR DESCRIPTION
readinessProbe had duplicate values for `initialDelaySeconds` and `periodSeconds` properties, which is invalid YAML and breaks any Helm usage completely.