### PR TITLE
Parameterise the image tags

### DIFF
--- a/charts/windmill/Chart.yaml
+++ b/charts/windmill/Chart.yaml
@@ -21,4 +21,4 @@ version: 1.0.2
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 1.62.0
+appVersion: 1.76.0

--- a/charts/windmill/templates/deploy_lsp.yaml
+++ b/charts/windmill/templates/deploy_lsp.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: lsp
-        image: ghcr.io/windmill-labs/windmill-lsp:latest
+        image: ghcr.io/windmill-labs/windmill-lsp:{{ .Values.lsp.image.tag }}
         imagePullPolicy: Always
         ports:
         - containerPort: 3001

--- a/charts/windmill/templates/deploy_windmill.yaml
+++ b/charts/windmill/templates/deploy_windmill.yaml
@@ -38,7 +38,7 @@ spec:
         {{ if .Values.enterprise.enabled }}
         image: ghcr.io/windmill-labs/windmill-ee
         {{ else }}
-        image: ghcr.io/windmill-labs/windmill:main
+        image: ghcr.io/windmill-labs/windmill:{{ .Values.windmill.image.tag }}
         {{ end }}
         imagePullPolicy: Always
         ports:

--- a/charts/windmill/templates/deploy_windmill_workers.yaml
+++ b/charts/windmill/templates/deploy_windmill_workers.yaml
@@ -28,7 +28,7 @@ spec:
         {{ if .Values.enterprise.enabled }}
         image: ghcr.io/windmill-labs/windmill-ee
         {{ else }}
-        image: ghcr.io/windmill-labs/windmill:main
+        image: ghcr.io/windmill-labs/windmill:{{ .Values.windmill.image.tag }}
         {{ end }}
         imagePullPolicy: Always
         ports:

--- a/charts/windmill/values.yaml
+++ b/charts/windmill/values.yaml
@@ -7,6 +7,8 @@ postgres:
   password: changeme
 
 windmill:
+  image:
+    tag: "1.76.0"
   # -- replica for the application frontend 
   frontendReplicas: 2
   # -- replicas for the workers, jobs are executed on the workers
@@ -42,6 +44,10 @@ windmill:
   #    }
   oauthConfig: |
       {}
+
+lsp:
+  image:
+    tag: "1.76.0"
 
 enterprise:
   # -- enable Windmill Enterprise , requires license key. 


### PR DESCRIPTION
In the current helm chart, the image tag is specified as `latest` or `main`. This makes it unpredictable to handle version upgrades and rollbacks.
This PR sets the image tag explicitly in values.yaml