### PR TITLE
Revert "Use `{{ .Release.Name }}` in Kubernetes resource names"

### DIFF
--- a/charts/windmill/templates/configmap.yaml
+++ b/charts/windmill/templates/configmap.yaml
@@ -1,9 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-configmap
+  name: windmill-configmap
   labels:
     app: windmill
 data:
   oauth.json: |
 {{ .Values.windmill.oauthConfig | indent 4}}
+        

--- a/charts/windmill/templates/deploy_lsp.yaml
+++ b/charts/windmill/templates/deploy_lsp.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-lsp
+  name: lsp
 spec:
   replicas: 2
   strategy:
@@ -48,7 +48,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-lsp
+  name: windmill-lsp
 spec:
   externalTrafficPolicy: Cluster
   ports:

--- a/charts/windmill/templates/deploy_postgres.yaml
+++ b/charts/windmill/templates/deploy_postgres.yaml
@@ -10,7 +10,7 @@ spec:
       app: windmill
   template:
     metadata:
-      labels:
+      labels: 
         app: windmill
         container: postgres
     spec:

--- a/charts/windmill/templates/deploy_windmill.yaml
+++ b/charts/windmill/templates/deploy_windmill.yaml
@@ -1,10 +1,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}
+  name: windmill
+
 spec:
   replicas: {{ .Values.windmill.frontendReplicas }}
-  strategy:
+  strategy: 
     type: RollingUpdate
     rollingUpdate:
       maxSurge: 3
@@ -17,7 +18,7 @@ spec:
     metadata:
       annotations:
         timestamp: {{ now | quote }}
-      labels:
+      labels: 
         app: windmill-app
         container: windmill-app
     spec:
@@ -94,7 +95,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-app
+  name: windmill-app
 spec:
   externalTrafficPolicy: Cluster
   ports:

--- a/charts/windmill/templates/deploy_windmill_workers.yaml
+++ b/charts/windmill/templates/deploy_windmill_workers.yaml
@@ -1,10 +1,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-workers
+  name: windmill-workers
 spec:
   replicas: {{ .Values.windmill.workerReplicas }}
-  strategy:
+  strategy: 
     type: RollingUpdate
     rollingUpdate:
       maxSurge: 3
@@ -14,7 +14,7 @@ spec:
       app: windmill-worker
   template:
     metadata:
-      labels:
+      labels: 
         app: windmill-worker
         container: windmill-worker
     spec:
@@ -77,7 +77,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-workers
+  name: windmill-workers
 spec:
   externalTrafficPolicy: Cluster
   ports:
@@ -95,7 +95,7 @@ status:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-worker-metrics
+  name: windmill-worker-metrics
 spec:
   clusterIP: None
   ports:


### PR DESCRIPTION
Reverts windmill-labs/windmill-helm-charts#9