### PR TITLE
Fix invalid key error

### DIFF
--- a/charts/windmill/Chart.yaml
+++ b/charts/windmill/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: windmill
 type: application
-version: 1.5.0
+version: 1.5.1
 appVersion: 1.103.0
 dependencies:
   - condition: postgresql.enabled

--- a/charts/windmill/templates/app.yaml
+++ b/charts/windmill/templates/app.yaml
@@ -73,10 +73,10 @@ spec:
           value: "true"
         {{ if .Values.windmill.databaseUrlSecretName }}
         - name: "DATABASE_URL"
-            valueFrom:
-              secretKeyRef:
-                name: "{{ .Values.windmill.databaseUrlSecretName }}"
-                key: url
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.windmill.databaseUrlSecretName }}"
+              key: url
         {{ else }}
         - name: "DATABASE_URL"
           value: "{{ .Values.windmill.databaseUrl }}"

--- a/charts/windmill/templates/workers.yaml
+++ b/charts/windmill/templates/workers.yaml
@@ -70,10 +70,10 @@ spec:
           value: "true"
         {{ if .Values.windmill.databaseUrlSecretName }}
         - name: "DATABASE_URL"
-            valueFrom:
-              secretKeyRef:
-                name: "{{ .Values.windmill.databaseUrlSecretName }}"
-                key: url
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.windmill.databaseUrlSecretName }}"
+              key: url
         {{ else }}
         - name: "DATABASE_URL"
           value: "{{ .Values.windmill.databaseUrl }}"


### PR DESCRIPTION
Fixes the following error when using `databaseUrlSecretName`:
> `Error: YAML parse error on Windmill/charts/windmill/templates/app.yaml: error converting YAML to JSON: yaml: line 66: did not find expected key Use --debug flag to render out invalid YAML`