### PR TITLE
Add option to customize databaseUrlSecretName key

### DIFF
--- a/charts/windmill/README.md.gotmpl
+++ b/charts/windmill/README.md.gotmpl
@@ -19,7 +19,7 @@
 
 If you would prefer to keep the PostgreSQL password or connection string out of the Helm values, there are two different possible approaches:
 
-1. Use `windmill.databaseUrlSecretName` to point at a Secret with a `url` key containing the entire database connection string.
+1. Use `windmill.databaseUrlSecretName` to point at a Secret with a `url` key or another key set with `windmill.databaseUrlSecretKey` that contains the entire database connection string.
 
 2. Use `windmill.databaseUrl` with [Dependent Environment Variables](https://kubernetes.io/docs/tasks/inject-data-application/define-interdependent-environment-variables/) together with `windmill.app.extraEnv` and `windmill.workers.extraEnv`.
 

--- a/charts/windmill/templates/app.yaml
+++ b/charts/windmill/templates/app.yaml
@@ -10,7 +10,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.windmill.appReplicas }}
-  strategy: 
+  strategy:
     type: RollingUpdate
     rollingUpdate:
       maxSurge: 3
@@ -76,7 +76,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: "{{ .Values.windmill.databaseUrlSecretName }}"
-              key: url
+              key: "{{ .Values.windmill.databaseUrlSecretKey }}"
         {{ else }}
         - name: "DATABASE_URL"
           value: "{{ .Values.windmill.databaseUrl }}"

--- a/charts/windmill/templates/worker-groups.yaml
+++ b/charts/windmill/templates/worker-groups.yaml
@@ -14,7 +14,7 @@ metadata:
     workerGroup: {{ $v.name }}
 spec:
   replicas: {{ $v.replicas }}
-  strategy: 
+  strategy:
     type: RollingUpdate
     rollingUpdate:
       maxSurge: 3
@@ -77,7 +77,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: "{{ $.Values.windmill.databaseUrlSecretName }}"
-              key: url
+              key: "{{ $.Values.windmill.databaseUrlSecretKey }}"
         {{ else }}
         - name: "DATABASE_URL"
           value: "{{ $.Values.windmill.databaseUrl }}"
@@ -153,6 +153,6 @@ spec:
     {{- with $v.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}
-{{- end }}    
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/windmill/values.yaml
+++ b/charts/windmill/values.yaml
@@ -38,8 +38,10 @@ windmill:
   lspReplicas: 2
   # -- replicas for the lsp containers used by the app
   multiplayerReplicas: 1
-  # -- name of the secret storing the database URI, take precedence over databaseUrl. The key of the url is 'url'
+  # -- name of the secret storing the database URI, take precedence over databaseUrl.
   databaseUrlSecretName: ""
+  # -- name of the key in secret storing the database URI. The default key of the url is 'url'
+  databaseUrlSecretKey: url
   # -- Postgres URI, pods will crashloop if database is unreachable, sets DATABASE_URL environment variable in app and worker container
   databaseUrl: postgres://postgres:windmill@windmill-postgresql/windmill?sslmode=disable
   # -- domain as shown in browser, this variable and `baseProtocol` are used as part of the BASE_URL environment variable in app and worker container and in the ingress resource, if enabled


### PR DESCRIPTION
Currently the `windmill.databaseUrlSecretName` requires the secret to contain a key named `url`. This PR adds an option to customize the name of the key being used in the secret.

The use case is to allow the usage of secrets that external tools or operators (like CNPG) create where this key can have other names (ex. CNPG creates a key named `uri` instead of `url` on their credentials secret)