### PR TITLE
feat: add securityContext

### DIFF
--- a/charts/windmill/templates/app.yaml
+++ b/charts/windmill/templates/app.yaml
@@ -119,8 +119,10 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+    {{- with .Values.windmill.app.securityContext }}
       securityContext:
-        runAsUser: 0
+{{ toYaml . | indent 8 }}
+    {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/windmill/templates/lsp.yaml
+++ b/charts/windmill/templates/lsp.yaml
@@ -55,9 +55,11 @@ spec:
     {{- with .Values.windmill.lsp.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}
-    {{- end }}                
+    {{- end }}
+    {{- with .Values.windmill.lsp.securityContext }}
       securityContext:
-        runAsUser: 0
+{{ toYaml . | indent 8 }}
+    {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/windmill/templates/multiplayer.yaml
+++ b/charts/windmill/templates/multiplayer.yaml
@@ -53,8 +53,10 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }} 
+    {{- with .Values.windmill.multiplayer.securityContext }}
       securityContext:
-        runAsUser: 0
+{{ toYaml . | indent 8 }}
+    {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/windmill/templates/worker-groups.yaml
+++ b/charts/windmill/templates/worker-groups.yaml
@@ -47,8 +47,10 @@ spec:
           privileged: true
         {{ else }}
         securityContext:
-          runAsUser: 0
-        {{end}}
+        {{- with $v.securityContext }}
+        {{ toYaml . | indent 8 }}
+        {{- end }}
+        {{ end }}
         {{ if $.Values.enterprise.enabled }}
         image: {{ default "ghcr.io/windmill-labs/windmill-ee" $.Values.windmill.image }}:{{ default $.Chart.AppVersion $.Values.windmill.tag }}
         {{ else }}

--- a/charts/windmill/values.yaml
+++ b/charts/windmill/values.yaml
@@ -83,6 +83,13 @@ windmill:
       # -- Tolerations to apply to the pods
       tolerations: []
 
+      # -- Security context to apply to the pods
+      securityContext:
+        # -- run as user. The default is 0 for root user
+        runAsUser: 0
+        # -- run explicitly as a non-root user. The default is false.
+        runAsNonRoot: false
+
       # -- Affinity rules to apply to the pods
       affinity: {}
 
@@ -113,6 +120,13 @@ windmill:
 
       # -- Tolerations to apply to the pods
       tolerations: []
+
+      # -- Security context to apply to the pods
+      securityContext:
+        # -- run as user. The default is 0 for root user
+        runAsUser: 0
+        # -- run explicitly as a non-root user. The default is false.
+        runAsNonRoot: false
 
       # -- Affinity rules to apply to the pods
       affinity: {}
@@ -145,6 +159,13 @@ windmill:
       # -- Tolerations to apply to the pods
       tolerations: []
 
+      # -- Security context to apply to the pods
+      securityContext:
+        # -- run as user. The default is 0 for root user
+        runAsUser: 0
+        # -- run explicitly as a non-root user. The default is false.
+        runAsNonRoot: false
+
       # -- Affinity rules to apply to the pods
       affinity: {}
 
@@ -169,6 +190,13 @@ windmill:
 
     # -- Tolerations to apply to the pods
     tolerations: []
+
+    # -- Security context to apply to the pods
+    securityContext:
+      # -- run as user. The default is 0 for root user
+      runAsUser: 0
+      # -- run explicitly as a non-root user. The default is false.
+      runAsNonRoot: false
 
     # -- Affinity rules to apply to the pods
     affinity: {}
@@ -203,6 +231,13 @@ windmill:
     # -- Tolerations to apply to the pods
     tolerations: []
 
+    # -- Security context to apply to the pods
+    securityContext:
+      # -- run as user. The default is 0 for root user
+      runAsUser: 0
+      # -- run explicitly as a non-root user. The default is false.
+      runAsNonRoot: false
+
     # -- Affinity rules to apply to the pods
     affinity: {}
 
@@ -235,6 +270,13 @@ windmill:
 
     # -- Tolerations to apply to the pods
     tolerations: []
+
+    # -- Security context to apply to the pods
+    securityContext:
+      # -- run as user. The default is 0 for root user
+      runAsUser: 0
+      # -- run explicitly as a non-root user. The default is false.
+      runAsNonRoot: false
 
     # -- Affinity rules to apply to the pods
     affinity: {}


### PR DESCRIPTION
Currently `securityContext` just has `runAsUser: 0` which just runs the container as the root user. This PR as the ability to configure for non-root user.