### PR TITLE
add optional extraContainers for sidecars

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ windmill:
       # -- Extra environment variables to apply to the pods
       extraEnv: []
 
+      # -- Extra sidecar containers
+      extraContainers: []
+
     # Thenative worker group will only execute native jobs. Windmill has a default worker group configuration for it
     - name: "native"
       replicas: 4
@@ -137,6 +140,9 @@ windmill:
 
       # -- Extra environment variables to apply to the pods
       extraEnv: []
+
+      # -- Extra sidecar containers
+      extraContainers: []
 
     - name: "gpu"
       replicas: 0

--- a/charts/windmill/templates/worker-groups.yaml
+++ b/charts/windmill/templates/worker-groups.yaml
@@ -45,7 +45,7 @@ spec:
       {{ end }}
       containers:
       {{- with $v.extraContainers }}
-      {{- toYaml . | nindent 8 }}
+      {{- toYaml . | nindent 6 }}
       {{- end }}
       - name: windmill-worker
        {{ if  $.Values.enterprise.nsjail }}

--- a/charts/windmill/templates/worker-groups.yaml
+++ b/charts/windmill/templates/worker-groups.yaml
@@ -44,6 +44,9 @@ spec:
       - name: {{ $.Values.windmill.imagePullSecrets }}
       {{ end }}
       containers:
+      {{- with $v.extraContainers }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       - name: windmill-worker
        {{ if  $.Values.enterprise.nsjail }}
        #because nsjail requires privileged access

--- a/charts/windmill/values.yaml
+++ b/charts/windmill/values.yaml
@@ -108,6 +108,9 @@ windmill:
 
       # -- Extra environment variables to apply to the pods
       extraEnv: []
+      # -- Extra sidecar containers
+      extraContainers: []
+
       volumes: []
       volumeMounts: []
 
@@ -146,6 +149,9 @@ windmill:
 
       # -- Extra environment variables to apply to the pods
       extraEnv: []
+      # -- Extra sidecar containers
+      extraContainers: []
+
       volumes: []
       volumeMounts: []
 
@@ -178,6 +184,9 @@ windmill:
 
       # -- Extra environment variables to apply to the pods
       extraEnv: []
+      # -- Extra sidecar containers
+      extraContainers: []
+
       volumes: []
       volumeMounts: []
   


### PR DESCRIPTION
Add optional attribute for workerGroups elements for "extraContainers."  Any elements specified in this optional attribute will be included verbatim next to the worker container.  This is intended to allow the Helm chart user to specify "sidecars" or other containers that run along side the main container.