### PR TITLE
fix Helm chart for ArgoCD formatting

### DIFF
--- a/charts/windmill/values.yaml
+++ b/charts/windmill/values.yaml
@@ -7,8 +7,8 @@ postgresql:
       enabled: true
     resources:
       limits:
-        cpu: "1000m"
-        memory: "2048Mi"
+        cpu: "1"
+        memory: "2Gi"
       requests:
         cpu: "250m"
         memory: "1024Mi"
@@ -100,11 +100,11 @@ windmill:
       # -- Resource limits and requests for the pods
       resources:
         requests:
-          memory: "1028Mi"
           cpu: "500m"
+          memory: "1Gi"
         limits:
-          memory: "2048Mi"
-          cpu: "1000m"
+          cpu: "1"
+          memory: "2Gi"
 
       # -- Extra environment variables to apply to the pods
       extraEnv: []
@@ -144,11 +144,11 @@ windmill:
       # -- Resource limits and requests for the pods
       resources:
         requests:
-          memory: "128Mi"
           cpu: "100m"
+          memory: "128Mi"
         limits:
-          memory: "256Mi"
           cpu: "200m"
+          memory: "256Mi"
 
       # -- Extra environment variables to apply to the pods
       extraEnv: []


### PR DESCRIPTION
The Windmill Helm chart produces some formatting which is inconsistent with eventual state of Kubernetes. This can cause flip-flopping with GitOps tools such as ArgoCD and Flux. To fix this, cpu and memory formatting is modified. First, values such as `1000m` are changed to `1` to match Kubernetes state. Ordering is modified so that cpu is first and memory is second, which also matches the ordering Kubernetes puts it in. 

See attached photo for error in ArgoCD. 

![Screenshot 2024-02-27 at 09 30 43](https://github.com/windmill-labs/windmill-helm-charts/assets/68659218/70c14fdd-08b9-4d97-beb9-3f1061049527)
