### PR TITLE
Fixes broken link on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <a href="#full-values">Full Values</a> •
   <a href="#local-s3">Local S3</a> •
   <a href="#caveats">Caveats</a> •  
-  <a href="#k8s-tips">Kubernetes Tips</a>
+  <a href="#kubernetes-hosting-tips">Kubernetes Tips</a>
 </p>
 
 <hr>


### PR DESCRIPTION
Fixes a broken link to the Kubernetes Hosting Tips section of the README.md file.