### PR TITLE
feat: allow deploying worker groups as statefulsets

### DIFF
--- a/charts/windmill/templates/_helpers.tpl
+++ b/charts/windmill/templates/_helpers.tpl
@@ -60,3 +60,16 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Validate controller kind, defaulting to "Deployment"
+*/}}
+{{- define "validateControllerKind" -}}
+{{- $validTypes := list "Deployment" "StatefulSet" -}}
+{{- $inputType := default "Deployment" . -}}
+{{- if has $inputType $validTypes -}}
+{{ $inputType }}
+{{- else -}}
+{{- fail (printf "Invalid controller type: %s. Must be either Deployment or StatefulSet" $inputType) -}}
+{{- end -}}
+{{- end -}}

--- a/charts/windmill/templates/worker-groups.yaml
+++ b/charts/windmill/templates/worker-groups.yaml
@@ -1,8 +1,9 @@
 {{- range $v := .Values.windmill.workerGroups }}
 {{ if and $v.replicas (gt (int $v.replicas) 0)}}
 ---
+{{- $controllerType := include "validateControllerKind" $v.controller }}
 apiVersion: apps/v1
-kind: Deployment
+kind: {{ $controllerType }}
 metadata:
   name: windmill-workers-{{ $v.name }}
   labels:
@@ -14,11 +15,19 @@ metadata:
     workerGroup: {{ $v.name }}
 spec:
   replicas: {{ $v.replicas }}
+  {{- if eq $controllerType "Deployment" }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
       maxSurge: 3
       maxUnavailable: 0
+  {{- else if eq $controllerType "StatefulSet" }}
+  serviceName: windmill-workers-{{ $v.name }}
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      partition: 0
+  {{- end }}
   selector:
     matchLabels:
       app: windmill-workers
@@ -183,6 +192,12 @@ spec:
     {{- with $v.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}
+{{- end }}
+{{- if eq $controllerType "StatefulSet" }}
+  {{- if $v.volumeClaimTemplates }}
+  volumeClaimTemplates:
+    {{- toYaml $v.volumeClaimTemplates | nindent 2 }}
+  {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/windmill/values.yaml
+++ b/charts/windmill/values.yaml
@@ -73,6 +73,9 @@ windmill:
     # workers configuration
     # The default worker group
     - name: "default"
+      # -- Controller to use. Valid options are "Deployment" and "StatefulSet"
+      controller: "Deployment"
+
       replicas: 3
       # -- Annotations to apply to the pods
       annotations: {}
@@ -98,7 +101,6 @@ windmill:
       # -- Security context to apply to the pod
       containerSecurityContext: {}
 
-
       # -- Affinity rules to apply to the pods
       affinity: {}
 
@@ -118,6 +120,9 @@ windmill:
       volumes: []
       volumeMounts: []
 
+      # -- Volume claim templates. Only applies when controller is "StatefulSet"
+      volumeClaimTemplates: []
+
       # -- command override
       command: []
 
@@ -125,6 +130,9 @@ windmill:
       exposeHostDocker: false
 
     - name: "native"
+      # -- Controller to use. Valid options are "Deployment" and "StatefulSet"
+      controller: "Deployment"
+
       replicas: 1
       # -- Annotations to apply to the pods
       annotations: {}
@@ -146,7 +154,6 @@ windmill:
         runAsNonRoot: false
       # -- Security context to apply to the pod
       containerSecurityContext: {}
-
 
       # -- Affinity rules to apply to the pods
       affinity: {}
@@ -173,7 +180,13 @@ windmill:
       # -- mount the docker socket inside the container to be able to run docker command as docker client to the host docker daemon
       exposeHostDocker: false
 
+      # -- Volume claim templates. Only applies when controller is "StatefulSet"
+      volumeClaimTemplates: []
+
     - name: "gpu"
+      # -- Controller to use. Valid options are "Deployment" and "StatefulSet"
+      controller: "Deployment"
+
       replicas: 0
       # -- Annotations to apply to the pods
       annotations: {}
@@ -196,7 +209,6 @@ windmill:
       # -- Security context to apply to the pod
       containerSecurityContext: {}
 
-
       # -- Affinity rules to apply to the pods
       affinity: {}
 
@@ -218,6 +230,9 @@ windmill:
 
       # -- mount the docker socket inside the container to be able to run docker command as docker client to the host docker daemon
       exposeHostDocker: false
+
+      # -- Volume claim templates. Only applies when controller is "StatefulSet"
+      volumeClaimTemplates: []
   # app configuration
   app:
     # -- Annotations to apply to the pods
@@ -263,7 +278,7 @@ windmill:
     volumes: []
 
     volumeMounts: []
-    
+
     # app autoscaling configuration
     autoscaling:
       # -- enable or disable autoscaling
@@ -284,7 +299,6 @@ windmill:
       enabled: false
       # -- annotations to apply to the service
       annotations: {}
-
 
   # lsp configuration
   lsp:


### PR DESCRIPTION
This PR allows deploying worker groups as StatefulSets instead of Deployments and adds support for `volumeClaimTemplates` which are StatefulSet-specific.

The use case for this would be to have a separate persistent and stable volume per pod in a worker group.

I've tested this on my own [Windmill deployment](https://github.com/invakid404/pi-cluster/blob/dead90ed0223978657367f44a711b86159666b11/apps/windmill/helmrelease.yaml#L26-L48), and I can confirm it works and doesn't introduce any breaking changes.