### PR TITLE
fix: add service account name to indexer

### DIFF
--- a/charts/windmill/templates/indexer.yaml
+++ b/charts/windmill/templates/indexer.yaml
@@ -33,6 +33,7 @@ spec:
 {{ toYaml . | indent 8 }}
   {{- end }}
     spec:
+      serviceAccountName: {{ template "windmill.serviceAccountName" . }}
       {{ if .Values.windmill.imagePullSecrets }}
       imagePullSecrets:
       - name: {{ .Values.windmill.imagePullSecrets }}


### PR DESCRIPTION
Closes service account is not configured for the indexer #87