### PR TITLE
Enable zero-replica worker groups for smooth scaling operations

### DIFF
--- a/charts/windmill/templates/worker-groups.yaml
+++ b/charts/windmill/templates/worker-groups.yaml
@@ -1,5 +1,5 @@
 {{- range $v := .Values.windmill.workerGroups }}
-{{ if and $v.replicas (gt (int $v.replicas) 0)}}
+{{ if and $v.replicas (ge (int $v.replicas) 0)}}
 ---
 {{- $controllerType := include "validateControllerKind" $v.controller }}
 apiVersion: apps/v1


### PR DESCRIPTION
## What does this PR do?
Updates the Helm template condition from `gt` to `ge` to support worker groups with 0 replicas, enabling smooth scaling operations (4→0→6) without deployment recreation.

## Note
This is my first PR to this project. Feedback welcome!