### PR TITLE
feat: add extraContainers support to indexer deployment

### DIFF
--- a/charts/windmill/templates/indexer.yaml
+++ b/charts/windmill/templates/indexer.yaml
@@ -39,6 +39,9 @@ spec:
       - name: {{ .Values.windmill.imagePullSecrets }}
       {{ end }}
       containers:
+      {{- with .Values.windmill.indexer.extraContainers }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       - name: windmill-indexer
         securityContext:
       {{- with .Values.windmill.indexer.containerSecurityContext }}

--- a/charts/windmill/values.yaml
+++ b/charts/windmill/values.yaml
@@ -459,6 +459,9 @@ windmill:
         memory: "2Gi"
         ephemeral-storage: "50Gi"
 
+    # -- Extra sidecar containers
+    extraContainers: []
+    
     # -- Extra environment variables to apply to the pods
     extraEnv: []
 


### PR DESCRIPTION
- Added extraContainers field to windmill.indexer configuration in values.yaml
- Updated indexer deployment template to include extraContainers before the main container
- Maintains consistency with app and worker-groups deployments


## Description

This PR adds support for `extraContainers` in the indexer deployment, bringing it in line with the app and worker-groups deployments that already have this functionality.

## Motivation

Currently, the indexer deployment doesn't support adding sidecar containers, while other Windmill components (app, worker-groups) do. This inconsistency limits deployment flexibility for users who need to run additional containers alongside the indexer (e.g., monitoring agents, log collectors, or proxy sidecars).

## Changes

- Added `extraContainers: []` field to `windmill.indexer` configuration in `values.yaml` (line 463)
- Updated `charts/windmill/templates/indexer.yaml` to include the extraContainers template block (lines 42-44)
- The implementation follows the exact same pattern used in `app.yaml` and `worker-groups.yaml` for consistency

## Implementation Details

The extraContainers are rendered before the main windmill-indexer container in the pod spec:
```yaml
containers:
{{- with .Values.windmill.indexer.extraContainers }}
{{- toYaml . | nindent 6 }}
{{- end }}
- name: windmill-indexer
  # ... main container config
```
