### PR TITLE
feat: support extraDeploy for arbitrary extra resources for externalSecrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ enterprise:
 | enterprise.s3CacheBucket                                        | string | `"mybucketname"`                                                                           | S3 bucket to use for dependency cache. Sets S3_CACHE_BUCKET environment variable in worker container                                                                                                             |
 | enterprise.samlMetadata                                         | string | `""`                                                                                       | SAML Metadata URL to enable SAML SSO (Can be set in the Instance Settings UI, which is the recommended method)                                                                                                   |
 | enterprise.scimToken                                            | string | `""`                                                                                       |                                                                                                                                                                                                                  |
+| extraDeploy                                                     | list   | `[]`                                                                                       | Support for deploying additional arbitrary resources. Use for External Secrets, ConfigMaps, etc.                                                                                                                 |
 | ingress.annotations                                             | object | `{}`                                                                                       |                                                                                                                                                                                                                  |
 | ingress.className                                               | string | `""`                                                                                       |                                                                                                                                                                                                                  |
 | ingress.enabled                                                 | bool   | `true`                                                                                     | enable/disable included ingress resource                                                                                                                                                                         |
@@ -578,6 +579,42 @@ You will also need to install cert-manager and configure an issuer. More details
 [here](https://cert-manager.io/docs/installation/#default-static-install) and
 [here](https://cert-manager.io/docs/tutorials/acme/nginx-ingress/#step-6---configure-a-lets-encrypt-issuer).
 Cert-manager can also be used with the other cloud providers.
+
+## Extra Deploy
+
+The `extraDeploy` parameter allows you to deploy additional arbitrary Kubernetes resources alongside Windmill. This is particularly useful for deploying External Secrets, ConfigMaps, custom Services, or any other Kubernetes resources that your Windmill deployment might need.
+
+Add the `extraDeploy` array to your values.yaml file with the Kubernetes resources you want to deploy:
+
+```yaml
+extraDeploy:
+  - apiVersion: external-secrets.io/v1beta1
+    kind: ExternalSecret
+    metadata:
+      name: windmill-database-secret
+      namespace: windmill
+    spec:
+      refreshInterval: 1h
+      secretStoreRef:
+        name: vault-backend
+        kind: SecretStore
+      target:
+        name: windmill-db-credentials
+        creationPolicy: Owner
+      data:
+      - secretKey: DATABASE_URL
+        remoteRef:
+          key: database/windmill
+          property: url
+```
+
+Then reference the created secret in your Windmill configuration:
+
+```yaml
+windmill:
+  databaseUrlSecretName: windmill-db-credentials
+  databaseUrlSecretKey: DATABASE_URL
+```
 
 ### Tailscale with TLS
 

--- a/charts/windmill/templates/_helpers.tpl
+++ b/charts/windmill/templates/_helpers.tpl
@@ -73,3 +73,16 @@ Validate controller kind, defaulting to "Deployment"
 {{- fail (printf "Invalid controller type: %s. Must be either Deployment or StatefulSet" $inputType) -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Renders a value that contains a template, with scope if present.
+Usage:
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
+*/}}
+{{- define "common.tplvalues.render" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- tpl (.value | toYaml) .context }}
+    {{- end }}
+{{- end -}}

--- a/charts/windmill/templates/extra-deploy.yaml
+++ b/charts/windmill/templates/extra-deploy.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/charts/windmill/values.yaml
+++ b/charts/windmill/values.yaml
@@ -561,3 +561,12 @@ hub-postgresql:
     postgresUser: postgres
     postgresPassword: windmill
     database: windmillhub
+
+# -- Support for deploying additional arbitrary resources. Use for External Secrets, etc.
+extraDeploy: []
+# - apiVersion: v1
+#   kind: ExternalSecret
+#   metadata:
+#     name: foo1
+#   data:
+#     bar: baz


### PR DESCRIPTION
This change introduces `.extraDeploy[]` to solve the problem deployment of extra Kubernetes resources in #234 .

Previously, users deploying Windmill with gitops tools may have used wrappers -- [Kustomization + a HelmRelease](https://fluxcd.io/flux/components/kustomize/kustomizations/) in FluxCD, or [nested Helm charts](https://helm.sh/docs/chart_template_guide/subcharts_and_globals/) in ArgoCD. 

Instead, this proposes including extra resources directly in the values of the chart and manage the release as a single helm deployment. This approach is fairly common elsewhere, e.g, the [bitnami charts](https://github.com/bitnami/charts).

Usage:

```sh
# two configmaps as "extra resources"; these could be anything
touch values.yaml
export CM1=$(kubectl create configmap foo --dry-run=client -o=yaml)
export CM2=$(kubectl create confimap bar --dry-run=client -o=yaml)
yq -i '.extraDeploy |= [env(CM1), env(CM2)]' values.yaml

helm template windmill ./charts/windmill --values values.yaml | grep 'extra-deploy' -A6
# Source: windmill/templates/extra-deploy.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  creationTimestamp: null
  name: foo
---
# Source: windmill/templates/extra-deploy.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  creationTimestamp: null
  name: bar
---
```