### PR TITLE
ci: publish helm chart to ghcr.io as OCI artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
     # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
     permissions:
       contents: write
+      packages: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -30,7 +31,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v3
         with:
-          version: v3.10.0
+          version: v3.14.4
 
       - name: Add Dependencies
         run: |
@@ -39,5 +40,27 @@ jobs:
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.7.0
+        with:
+          skip_existing: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Publish chart to GHCR (OCI)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          echo "$GITHUB_TOKEN" | helm registry login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+
+          # chart-releaser packages charts under .cr-release-packages/
+          shopt -s nullglob
+          packages=(.cr-release-packages/*.tgz)
+          if [ ${#packages[@]} -eq 0 ]; then
+            echo "No packaged charts found in .cr-release-packages/, nothing to push."
+            exit 0
+          fi
+
+          for pkg in "${packages[@]}"; do
+            echo "Pushing $pkg to oci://ghcr.io/windmill-labs/charts"
+            helm push "$pkg" oci://ghcr.io/windmill-labs/charts
+          done


### PR DESCRIPTION
## Summary

Customers on network-restricted clusters that can proxy ghcr.io (but not github.com / github.io) can't install the chart from GitHub Pages or the Releases tarball. Resume publishing the chart to ghcr.io as an OCI artifact so it can be pulled via internal OCI proxies (e.g. an Artifact Registry mirror of ghcr.io).

The previously published `oci://ghcr.io/windmill-labs/windmill` artifact (last seen at 1.41.0) was a one-off manual `helm push` from years ago and was never automated. This wires it into the existing `release.yml` so every chart bump is published.

## Changes

- Add `packages: write` permission to the release job so the workflow can push to ghcr.io.
- Bump `azure/setup-helm` to `v3.14.4` (well past the helm 3.8.0 OCI-GA cutoff).
- Pass `skip_existing: true` to `chart-releaser-action` so re-runs are idempotent (matters when the new OCI step fails and we retry).
- After `chart-releaser-action` packages the chart into `.cr-release-packages/`, log in to ghcr.io with `GITHUB_TOKEN` and `helm push` every `*.tgz` to **`oci://ghcr.io/windmill-labs/charts`** (final artifact: `oci://ghcr.io/windmill-labs/charts/windmill:<version>`).

### Why a new path (`charts/windmill` rather than `windmill`)

The existing `ghcr.io/windmill-labs/windmill` namespace is the docker image. Reusing it for chart artifacts is technically possible (OCI lets different mediaTypes coexist on the same path) but the chart's `1.x` / `4.x` version tags would collide visually with old docker image tags. A dedicated `charts/` namespace keeps things clean and matches what other projects (e.g. bitnami) do on ghcr.

## Test plan

- [ ] After merge, trigger the workflow via \`workflow_dispatch\` (or wait for the next chart bump). Confirm the \`Publish chart to GHCR (OCI)\` step succeeds.
- [ ] From a machine that can reach ghcr.io: \`helm pull oci://ghcr.io/windmill-labs/charts/windmill --version <new-version>\` returns the chart.
- [ ] Confirm the package is listed under https://github.com/orgs/windmill-labs/packages and is public (may require a one-time visibility flip on first publish).
- [ ] Verify the existing GitHub Pages / Releases publication still works (chart-releaser-action output unchanged).