### PR TITLE
ci: add claude/codex/pi automated PR reviews

### DIFF
--- a/.claude/review-prompt.md
+++ b/.claude/review-prompt.md
@@ -1,0 +1,4 @@
+# Claude output format
+
+- Use inline comments at the relevant lines for specific issues.
+- Use a top-level comment for the summary, severity-tagged finding list, and the test-coverage assessment.

--- a/.github/codex/pr-review.prompt.md
+++ b/.github/codex/pr-review.prompt.md
@@ -1,0 +1,5 @@
+# Codex output format
+
+- Read `./.github/codex/pr-review-context.md` for PR metadata and the diff commands.
+- Return a markdown PR comment starting with `## Codex Review`.
+- Tag each finding with a severity (P0 / P1 / P2), file path, and line number when known confidently.

--- a/.github/pi/pr-review.prompt.md
+++ b/.github/pi/pr-review.prompt.md
@@ -1,0 +1,6 @@
+# Pi output format
+
+- Read `./.github/pi/pr-review-context.md` for PR metadata and the diff commands.
+- Return a markdown PR comment starting with `## Pi Review`.
+- Tag each finding with a severity (P0 / P1 / P2), file path, and line number when known confidently.
+- Output ONLY the final review markdown — no preamble, no thinking, no tool transcripts.

--- a/.github/workflows/check-org-membership.yml
+++ b/.github/workflows/check-org-membership.yml
@@ -1,0 +1,83 @@
+name: Check Organization Membership
+
+on:
+  workflow_call:
+    inputs:
+      commenter:
+        required: false
+        type: string
+        default: ''
+        description: 'The username to check. Auto-detected from the event context if not provided.'
+      organization:
+        required: false
+        type: string
+        default: 'windmill-labs'
+        description: 'The organization to check membership for'
+      trusted_bot:
+        required: false
+        type: string
+        default: 'windmill-internal-app[bot]'
+        description: 'The trusted bot username to allow'
+    secrets:
+      access_token:
+        required: true
+        description: 'The access token to use for org membership check'
+    outputs:
+      is_member:
+        description: 'Whether the user is an organization member or trusted bot'
+        value: ${{ jobs.check-membership.outputs.is_member }}
+
+jobs:
+  check-membership:
+    runs-on: ubuntu-latest
+    outputs:
+      is_member: ${{ steps.check-membership.outputs.is_member }}
+    steps:
+      - name: Determine commenter
+        id: determine-commenter
+        run: |
+          COMMENTER="${{ inputs.commenter }}"
+          if [[ -z "$COMMENTER" ]]; then
+            if [[ "${{ github.event_name }}" == "issue_comment" || \
+                  "${{ github.event_name }}" == "pull_request_review_comment" ]]; then
+              COMMENTER="${{ github.event.comment.user.login }}"
+            elif [[ "${{ github.event_name }}" == "pull_request_review" ]]; then
+              COMMENTER="${{ github.event.review.user.login }}"
+            else
+              COMMENTER="${{ github.event.issue.user.login }}"
+            fi
+          fi
+          echo "commenter=$COMMENTER" >> $GITHUB_OUTPUT
+
+      - name: Check organization membership
+        id: check-membership
+        env:
+          ORG_ACCESS_TOKEN: ${{ secrets.access_token }}
+          COMMENTER: ${{ steps.determine-commenter.outputs.commenter }}
+          ORG: ${{ inputs.organization }}
+          TRUSTED_BOT: ${{ inputs.trusted_bot }}
+        run: |
+          # 1. Allow the trusted bot straight away
+          if [[ "$COMMENTER" == "$TRUSTED_BOT" ]]; then
+            echo "is_member=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # 2. Disallow other bots
+          if [[ "${COMMENTER}" =~ \[bot\]$ ]]; then
+            echo "is_member=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # 3. Otherwise check if the user is a member of the organization
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "Authorization: token $ORG_ACCESS_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/orgs/$ORG/members/$COMMENTER")
+
+          if [ "$STATUS" -eq 204 ]; then
+            echo "is_member=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_member=false" >> $GITHUB_OUTPUT
+          fi

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -1,0 +1,270 @@
+name: Codex Auto Review
+
+on:
+  pull_request:
+    types: [ready_for_review, opened, synchronize]
+  workflow_call:
+    inputs:
+      pr_number:
+        description: 'PR number to review'
+        required: true
+        type: number
+      extra_prompt:
+        description: 'Additional reviewer instructions appended to the standard review prompt'
+        required: false
+        type: string
+        default: ''
+      triggered_by:
+        description: 'GitHub username that triggered this review (for audit only)'
+        required: false
+        type: string
+        default: ''
+    secrets:
+      CODEX_AUTH_JSON:
+        required: false
+
+concurrency:
+  group: codex-review-${{ inputs.pr_number || github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check-membership:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/check-org-membership.yml
+    with:
+      commenter: ${{ github.event.pull_request.user.login }}
+    secrets:
+      access_token: ${{ secrets.ORG_ACCESS_TOKEN }}
+
+  codex-review:
+    needs: check-membership
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: |
+      always() &&
+      (
+        needs.check-membership.result == 'skipped' ||
+        (needs.check-membership.result == 'success' && needs.check-membership.outputs.is_member == 'true')
+      ) &&
+      (
+        github.event_name == 'workflow_call' ||
+        (github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false)
+      )
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Check Codex configuration
+        id: codex_config
+        env:
+          CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+        run: |
+          if [ -n "$CODEX_AUTH_JSON" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "CODEX_AUTH_JSON is not configured; skipping Codex review."
+          fi
+
+      - name: Resolve PR metadata
+        if: steps.codex_config.outputs.enabled == 'true'
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_TITLE: ${{ github.event.pull_request.title }}
+          EVENT_BODY: ${{ github.event.pull_request.body }}
+          EVENT_FORK: ${{ github.event.pull_request.head.repo.fork }}
+        run: |
+          if [ -n "$INPUT_PR_NUMBER" ]; then
+            PR_JSON=$(gh pr view "$INPUT_PR_NUMBER" --repo "${{ github.repository }}" \
+              --json number,baseRefName,baseRefOid,headRefOid,title,body,isCrossRepository)
+            PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
+            BASE_REF=$(echo "$PR_JSON" | jq -r '.baseRefName')
+            BASE_SHA=$(echo "$PR_JSON" | jq -r '.baseRefOid')
+            HEAD_SHA=$(echo "$PR_JSON" | jq -r '.headRefOid')
+            PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
+            PR_BODY=$(echo "$PR_JSON" | jq -r '.body // ""')
+            IS_FORK=$(echo "$PR_JSON" | jq -r '.isCrossRepository')
+          else
+            PR_NUMBER="$EVENT_PR_NUMBER"
+            BASE_REF="$EVENT_BASE_REF"
+            BASE_SHA="$EVENT_BASE_SHA"
+            HEAD_SHA="$EVENT_HEAD_SHA"
+            PR_TITLE="$EVENT_TITLE"
+            PR_BODY="$EVENT_BODY"
+            IS_FORK="$EVENT_FORK"
+          fi
+          if [ "$IS_FORK" = "true" ]; then
+            echo "Skipping Codex review for fork PR."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          {
+            echo "skip=false"
+            echo "pr_number=$PR_NUMBER"
+            echo "base_ref=$BASE_REF"
+            echo "base_sha=$BASE_SHA"
+            echo "head_sha=$HEAD_SHA"
+            echo 'title<<PR_TITLE_EOF'
+            printf '%s\n' "$PR_TITLE"
+            echo 'PR_TITLE_EOF'
+            echo 'body<<PR_BODY_EOF'
+            printf '%s\n' "$PR_BODY"
+            echo 'PR_BODY_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Checkout repository
+        if: steps.codex_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
+        uses: actions/checkout@v5
+        with:
+          ref: refs/pull/${{ steps.pr.outputs.pr_number }}/merge
+          fetch-depth: 1
+
+      - name: Set up Node.js
+        if: steps.codex_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install Codex CLI
+        if: steps.codex_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
+        run: npm install --global @openai/codex@0.128.0
+
+      - name: Configure file-backed Codex auth
+        if: steps.codex_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
+        env:
+          CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+        run: |
+          CODEX_HOME="$HOME/.codex"
+          echo "CODEX_HOME=$CODEX_HOME" >> "$GITHUB_ENV"
+          mkdir -p "$CODEX_HOME"
+          chmod 700 "$CODEX_HOME"
+          cat > "$CODEX_HOME/config.toml" <<'EOF'
+          cli_auth_credentials_store = "file"
+          EOF
+          printf '%s' "$CODEX_AUTH_JSON" > "$CODEX_HOME/auth.json"
+          chmod 600 "$CODEX_HOME/auth.json"
+          node -e 'JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"))' "$CODEX_HOME/auth.json"
+
+      - name: Pre-fetch base and head refs for the PR
+        if: steps.codex_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
+        env:
+          PR_BASE_REF: ${{ steps.pr.outputs.base_ref }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+        run: |
+          git fetch --no-tags origin \
+            "$PR_BASE_REF" \
+            "+refs/pull/$PR_NUMBER/head"
+
+      - name: Fetch prior PR discussion
+        if: steps.codex_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+        run: |
+          gh api "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100" \
+            --jq '[.[] | {user: .user.login, created_at: .created_at, body: (.body | .[:4000])}] | sort_by(.created_at) | .[-20:]' \
+            > prior-comments.json || echo "[]" > prior-comments.json
+
+      - name: Write Codex review context
+        if: steps.codex_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
+        env:
+          PR_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          PR_BASE_SHA: ${{ steps.pr.outputs.base_sha }}
+          PR_HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          PR_TITLE: ${{ steps.pr.outputs.title }}
+          PR_BODY: ${{ steps.pr.outputs.body }}
+          EXTRA_PROMPT: ${{ inputs.extra_prompt }}
+        run: |
+          mkdir -p .github/codex
+          node <<'NODE'
+          const fs = require('fs');
+          const lines = [
+            `Repository: ${process.env.PR_REPOSITORY}`,
+            `PR number: ${process.env.PR_NUMBER}`,
+            `Base SHA: ${process.env.PR_BASE_SHA}`,
+            `Head SHA: ${process.env.PR_HEAD_SHA}`,
+            '',
+            'PR title:',
+            process.env.PR_TITLE || '(empty)',
+            '',
+            'PR body:',
+            process.env.PR_BODY || '(empty)',
+            '',
+            'Changed commits command:',
+            `git log --oneline ${process.env.PR_BASE_SHA}...${process.env.PR_HEAD_SHA}`,
+            '',
+            'Changed files command:',
+            `git diff --stat ${process.env.PR_BASE_SHA}...${process.env.PR_HEAD_SHA}`,
+            '',
+            'Full review diff command:',
+            `git diff --unified=0 ${process.env.PR_BASE_SHA}...${process.env.PR_HEAD_SHA}`
+          ];
+          if (process.env.EXTRA_PROMPT && process.env.EXTRA_PROMPT.trim()) {
+            lines.push('', 'Additional reviewer instructions:', process.env.EXTRA_PROMPT.trim());
+          }
+          if (fs.existsSync('prior-comments.json')) {
+            try {
+              const comments = JSON.parse(fs.readFileSync('prior-comments.json', 'utf8'));
+              if (Array.isArray(comments) && comments.length > 0) {
+                lines.push(
+                  '',
+                  'Prior PR discussion (most recent up to 20 comments):',
+                  '',
+                  'If you have already reviewed this PR (look for your own earlier "## Codex Review" comment), focus on what changed since then per the diff and respect any decisions the human made in replies. Do not re-flag findings the human already pushed back on.',
+                  ''
+                );
+                for (const c of comments) {
+                  lines.push(`### @${c.user} (${c.created_at})`, '', c.body, '', '---', '');
+                }
+              }
+            } catch (_) {}
+          }
+          fs.writeFileSync('.github/codex/pr-review-context.md', `${lines.join('\n')}\n`);
+          NODE
+
+      - name: Run Codex review
+        if: steps.codex_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
+        run: |
+          cat REVIEW.md .github/codex/pr-review.prompt.md > /tmp/codex-prompt.md
+          codex exec \
+            -C "$GITHUB_WORKSPACE" \
+            -m gpt-5.5 \
+            -c 'model_reasoning_effort="xhigh"' \
+            -s danger-full-access \
+            -o codex-final-message.md \
+            - < /tmp/codex-prompt.md
+
+      - name: Post Codex review comment
+        if: steps.codex_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const fs = require('fs');
+            const path = `${process.env.GITHUB_WORKSPACE}/codex-final-message.md`;
+            if (!fs.existsSync(path)) {
+              core.info('Codex did not produce a final message; skipping PR comment.');
+              return;
+            }
+            const body = fs.readFileSync(path, 'utf8').trim();
+            if (!body) {
+              core.info('Codex final message was empty; skipping PR comment.');
+              return;
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: Number(process.env.PR_NUMBER),
+              body,
+            });

--- a/.github/workflows/pi-pr-review.yml
+++ b/.github/workflows/pi-pr-review.yml
@@ -1,0 +1,286 @@
+name: Pi Auto Review
+
+on:
+  pull_request:
+    types: [ready_for_review, opened, synchronize]
+  workflow_call:
+    inputs:
+      pr_number:
+        description: 'PR number to review'
+        required: true
+        type: number
+      extra_prompt:
+        description: 'Additional reviewer instructions appended to the standard review prompt'
+        required: false
+        type: string
+        default: ''
+      triggered_by:
+        description: 'GitHub username that triggered this review (for audit only)'
+        required: false
+        type: string
+        default: ''
+    secrets:
+      DEEPSEEK_API_KEY:
+        required: false
+
+concurrency:
+  group: pi-review-${{ inputs.pr_number || github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check-membership:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/check-org-membership.yml
+    with:
+      commenter: ${{ github.event.pull_request.user.login }}
+    secrets:
+      access_token: ${{ secrets.ORG_ACCESS_TOKEN }}
+
+  pi-review:
+    needs: check-membership
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: |
+      always() &&
+      (
+        needs.check-membership.result == 'skipped' ||
+        (needs.check-membership.result == 'success' && needs.check-membership.outputs.is_member == 'true')
+      ) &&
+      (
+        github.event_name == 'workflow_call' ||
+        (github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false)
+      )
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Check Pi configuration
+        id: pi_config
+        env:
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+        run: |
+          if [ -n "$DEEPSEEK_API_KEY" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "DEEPSEEK_API_KEY is not configured; skipping Pi review."
+          fi
+
+      - name: Resolve PR metadata
+        if: steps.pi_config.outputs.enabled == 'true'
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_TITLE: ${{ github.event.pull_request.title }}
+          EVENT_BODY: ${{ github.event.pull_request.body }}
+          EVENT_FORK: ${{ github.event.pull_request.head.repo.fork }}
+        run: |
+          if [ -n "$INPUT_PR_NUMBER" ]; then
+            PR_JSON=$(gh pr view "$INPUT_PR_NUMBER" --repo "${{ github.repository }}" \
+              --json number,baseRefName,baseRefOid,headRefOid,title,body,isCrossRepository)
+            PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
+            BASE_REF=$(echo "$PR_JSON" | jq -r '.baseRefName')
+            BASE_SHA=$(echo "$PR_JSON" | jq -r '.baseRefOid')
+            HEAD_SHA=$(echo "$PR_JSON" | jq -r '.headRefOid')
+            PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
+            PR_BODY=$(echo "$PR_JSON" | jq -r '.body // ""')
+            IS_FORK=$(echo "$PR_JSON" | jq -r '.isCrossRepository')
+          else
+            PR_NUMBER="$EVENT_PR_NUMBER"
+            BASE_REF="$EVENT_BASE_REF"
+            BASE_SHA="$EVENT_BASE_SHA"
+            HEAD_SHA="$EVENT_HEAD_SHA"
+            PR_TITLE="$EVENT_TITLE"
+            PR_BODY="$EVENT_BODY"
+            IS_FORK="$EVENT_FORK"
+          fi
+          if [ "$IS_FORK" = "true" ]; then
+            echo "Skipping Pi review for fork PR."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          {
+            echo "skip=false"
+            echo "pr_number=$PR_NUMBER"
+            echo "base_ref=$BASE_REF"
+            echo "base_sha=$BASE_SHA"
+            echo "head_sha=$HEAD_SHA"
+            echo 'title<<PR_TITLE_EOF'
+            printf '%s\n' "$PR_TITLE"
+            echo 'PR_TITLE_EOF'
+            echo 'body<<PR_BODY_EOF'
+            printf '%s\n' "$PR_BODY"
+            echo 'PR_BODY_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Checkout repository
+        if: steps.pi_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
+        uses: actions/checkout@v5
+        with:
+          ref: refs/pull/${{ steps.pr.outputs.pr_number }}/merge
+          fetch-depth: 1
+
+      - name: Set up Node.js
+        if: steps.pi_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install Pi CLI
+        if: steps.pi_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
+        run: npm install --global @mariozechner/pi-coding-agent
+
+      - name: Pre-fetch base and head refs for the PR
+        if: steps.pi_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
+        env:
+          PR_BASE_REF: ${{ steps.pr.outputs.base_ref }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+        run: |
+          git fetch --no-tags origin \
+            "$PR_BASE_REF" \
+            "+refs/pull/$PR_NUMBER/head"
+
+      - name: Fetch prior PR discussion
+        if: steps.pi_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+        run: |
+          gh api "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100" \
+            --jq '[.[] | {user: .user.login, created_at: .created_at, body: (.body | .[:4000])}] | sort_by(.created_at) | .[-20:]' \
+            > prior-comments.json || echo "[]" > prior-comments.json
+
+      - name: Write Pi review context
+        if: steps.pi_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
+        env:
+          PR_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          PR_BASE_SHA: ${{ steps.pr.outputs.base_sha }}
+          PR_HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          PR_TITLE: ${{ steps.pr.outputs.title }}
+          PR_BODY: ${{ steps.pr.outputs.body }}
+          EXTRA_PROMPT: ${{ inputs.extra_prompt }}
+        run: |
+          mkdir -p .github/pi
+          node <<'NODE'
+          const fs = require('fs');
+          const lines = [
+            `Repository: ${process.env.PR_REPOSITORY}`,
+            `PR number: ${process.env.PR_NUMBER}`,
+            `Base SHA: ${process.env.PR_BASE_SHA}`,
+            `Head SHA: ${process.env.PR_HEAD_SHA}`,
+            '',
+            'PR title:',
+            process.env.PR_TITLE || '(empty)',
+            '',
+            'PR body:',
+            process.env.PR_BODY || '(empty)',
+            '',
+            'Changed commits command:',
+            `git log --oneline ${process.env.PR_BASE_SHA}...${process.env.PR_HEAD_SHA}`,
+            '',
+            'Changed files command:',
+            `git diff --stat ${process.env.PR_BASE_SHA}...${process.env.PR_HEAD_SHA}`,
+            '',
+            'Full review diff command:',
+            `git diff --unified=0 ${process.env.PR_BASE_SHA}...${process.env.PR_HEAD_SHA}`
+          ];
+          if (process.env.EXTRA_PROMPT && process.env.EXTRA_PROMPT.trim()) {
+            lines.push('', 'Additional reviewer instructions:', process.env.EXTRA_PROMPT.trim());
+          }
+          if (fs.existsSync('prior-comments.json')) {
+            try {
+              const comments = JSON.parse(fs.readFileSync('prior-comments.json', 'utf8'));
+              if (Array.isArray(comments) && comments.length > 0) {
+                lines.push(
+                  '',
+                  'Prior PR discussion (most recent up to 20 comments):',
+                  '',
+                  'If you have already reviewed this PR (look for your own earlier "## Pi Review (DeepSeek V4)" comment), focus on what changed since then per the diff and respect any decisions the human made in replies. Do not re-flag findings the human already pushed back on.',
+                  ''
+                );
+                for (const c of comments) {
+                  lines.push(`### @${c.user} (${c.created_at})`, '', c.body, '', '---', '');
+                }
+              }
+            } catch (_) {}
+          }
+          fs.writeFileSync('.github/pi/pr-review-context.md', `${lines.join('\n')}\n`);
+          NODE
+
+      - name: Run Pi review
+        if: steps.pi_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
+        env:
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          PI_SKIP_VERSION_CHECK: '1'
+        run: |
+          set -o pipefail
+          cat REVIEW.md .github/pi/pr-review.prompt.md > /tmp/pi-prompt.md
+          pi -p \
+            --provider deepseek \
+            --model deepseek-v4-pro \
+            --tools read,grep,find,ls,bash \
+            --mode json \
+            < /tmp/pi-prompt.md \
+            | tee pi-events.jsonl \
+            | jq -rc --unbuffered '
+                if .type == "agent_start" then "🤖 pi agent started"
+                elif .type == "turn_start" then "── turn ──"
+                elif .type == "message_end" then
+                  "[\(.message.role)] " + (
+                    (.message.content // [])
+                    | map(
+                        if .type == "text" then "text(\(.text | length)c)"
+                        elif .type == "tool_use" then "🔧 \(.name) \(.input | @json | .[:160])"
+                        elif .type == "tool_result" then "✅ result"
+                        else .type
+                        end
+                      )
+                    | join(" | ")
+                  )
+                elif .type == "turn_end" then "── turn done (\((.toolResults // []) | length) tool result(s)) ──"
+                elif .type == "agent_end" then "🏁 pi agent done"
+                else empty
+                end
+              '
+
+          jq -r '
+            select(.type == "agent_end")
+            | .messages
+            | map(select(.role == "assistant"))
+            | last
+            | (.content[]? | select(.type == "text") | .text)
+          ' pi-events.jsonl > pi-final-message.md
+
+      - name: Post Pi review comment
+        if: steps.pi_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const fs = require('fs');
+            const path = `${process.env.GITHUB_WORKSPACE}/pi-final-message.md`;
+            if (!fs.existsSync(path)) {
+              core.info('Pi did not produce a final message; skipping PR comment.');
+              return;
+            }
+            const body = fs.readFileSync(path, 'utf8').trim();
+            if (!body) {
+              core.info('Pi final message was empty; skipping PR comment.');
+              return;
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: Number(process.env.PR_NUMBER),
+              body,
+            });

--- a/.github/workflows/pr-ready-review.yml
+++ b/.github/workflows/pr-ready-review.yml
@@ -1,0 +1,127 @@
+name: Claude Auto Review
+
+on:
+  pull_request:
+    types: [ready_for_review, opened]
+  workflow_call:
+    inputs:
+      pr_number:
+        description: 'PR number to review'
+        required: true
+        type: number
+      extra_prompt:
+        description: 'Additional reviewer instructions appended to the standard review prompt'
+        required: false
+        type: string
+        default: ''
+      triggered_by:
+        description: 'GitHub username that triggered this review (for audit only)'
+        required: false
+        type: string
+        default: ''
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN:
+        required: true
+
+concurrency:
+  group: claude-review-${{ inputs.pr_number || github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check-membership:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/check-org-membership.yml
+    with:
+      commenter: ${{ github.event.pull_request.user.login }}
+    secrets:
+      access_token: ${{ secrets.ORG_ACCESS_TOKEN }}
+
+  auto-review:
+    needs: check-membership
+    runs-on: ubuntu-latest
+    if: |
+      always() &&
+      (
+        needs.check-membership.result == 'skipped' ||
+        (needs.check-membership.result == 'success' && needs.check-membership.outputs.is_member == 'true')
+      ) &&
+      (
+        github.event_name == 'workflow_call' ||
+        (github.event.pull_request.draft == false || github.event.pull_request.ready_for_review == true)
+      )
+    permissions:
+      contents: read
+      pull-requests: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Resolve PR number
+        id: resolve
+        env:
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [ -n "$INPUT_PR_NUMBER" ]; then
+            echo "pr_number=$INPUT_PR_NUMBER" >> "$GITHUB_OUTPUT"
+          else
+            echo "pr_number=$EVENT_PR_NUMBER" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fetch prior PR discussion
+        id: prior
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
+        run: |
+          gh api "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100" \
+            --jq '[.[] | {user: .user.login, created_at: .created_at, body: (.body | .[:4000])}] | sort_by(.created_at) | .[-20:]' \
+            > prior-comments.json || echo "[]" > prior-comments.json
+          jq -r '
+            if length == 0 then ""
+            else
+              "## Prior PR discussion (most recent up to 20 comments)\n\nIf you have already reviewed this PR (look for your own earlier comment), focus on what changed since then per the diff and respect any decisions the human made in replies. Do not re-flag findings the human already pushed back on.\n\n" +
+              (map("### @\(.user) (\(.created_at))\n\n\(.body)") | join("\n\n---\n\n"))
+            end
+          ' prior-comments.json > prior-comments.md
+
+      - name: Read review prompt
+        id: review-prompt
+        env:
+          EXTRA_PROMPT: ${{ inputs.extra_prompt }}
+        run: |
+          {
+            echo 'REVIEW_PROMPT<<EOF'
+            cat REVIEW.md
+            echo ''
+            cat .claude/review-prompt.md
+            if [ -n "$EXTRA_PROMPT" ]; then
+              echo ''
+              echo '## Additional reviewer instructions'
+              echo ''
+              printf '%s\n' "$EXTRA_PROMPT"
+            fi
+            if [ -s prior-comments.md ]; then
+              echo ''
+              cat prior-comments.md
+            fi
+            echo 'EOF'
+          } >> "$GITHUB_ENV"
+
+      - name: Automatic PR Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ steps.resolve.outputs.pr_number }}
+
+            ${{ env.REVIEW_PROMPT }}
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --model opus

--- a/.github/workflows/pr-review-commands.yml
+++ b/.github/workflows/pr-review-commands.yml
@@ -1,0 +1,119 @@
+name: PR Review Commands
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  parse:
+    if: github.event.issue.pull_request != null
+    runs-on: ubuntu-latest
+    outputs:
+      command: ${{ steps.parse.outputs.command }}
+      extra_prompt: ${{ steps.parse.outputs.extra_prompt }}
+    steps:
+      - name: Parse command from comment
+        id: parse
+        env:
+          BODY: ${{ github.event.comment.body }}
+        run: |
+          FIRST_LINE=$(printf '%s' "$BODY" | head -n 1 | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
+          FIRST_WORD=${FIRST_LINE%% *}
+          case "$FIRST_WORD" in
+            /review|/codex|/pi|/claude)
+              COMMAND="${FIRST_WORD#/}"
+              REMAINDER_FIRST_LINE=${FIRST_LINE#"$FIRST_WORD"}
+              REMAINDER_FIRST_LINE=${REMAINDER_FIRST_LINE# }
+              REST=$(printf '%s' "$BODY" | tail -n +2)
+              {
+                echo "command=$COMMAND"
+                echo 'extra_prompt<<EXTRA_EOF'
+                if [ -n "$REMAINDER_FIRST_LINE" ]; then
+                  printf '%s\n' "$REMAINDER_FIRST_LINE"
+                fi
+                if [ -n "$REST" ]; then
+                  printf '%s\n' "$REST"
+                fi
+                echo 'EXTRA_EOF'
+              } >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "command=" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+  check-membership:
+    needs: parse
+    if: needs.parse.outputs.command != ''
+    uses: ./.github/workflows/check-org-membership.yml
+    secrets:
+      access_token: ${{ secrets.ORG_ACCESS_TOKEN }}
+
+  acknowledge:
+    needs: [parse, check-membership]
+    if: needs.parse.outputs.command != '' && needs.check-membership.outputs.is_member == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: React to comment with eyes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          gh api -X POST \
+            "/repos/$REPO/issues/comments/$COMMENT_ID/reactions" \
+            -f content=eyes >/dev/null
+
+  claude:
+    needs: [parse, check-membership]
+    if: |
+      needs.check-membership.outputs.is_member == 'true' &&
+      (needs.parse.outputs.command == 'review' || needs.parse.outputs.command == 'claude')
+    permissions:
+      contents: read
+      pull-requests: read
+      id-token: write
+    uses: ./.github/workflows/pr-ready-review.yml
+    with:
+      pr_number: ${{ github.event.issue.number }}
+      extra_prompt: ${{ needs.parse.outputs.extra_prompt }}
+      triggered_by: ${{ github.event.comment.user.login }}
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+  codex:
+    needs: [parse, check-membership]
+    if: |
+      needs.check-membership.outputs.is_member == 'true' &&
+      (needs.parse.outputs.command == 'review' || needs.parse.outputs.command == 'codex')
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    uses: ./.github/workflows/codex-pr-review.yml
+    with:
+      pr_number: ${{ github.event.issue.number }}
+      extra_prompt: ${{ needs.parse.outputs.extra_prompt }}
+      triggered_by: ${{ github.event.comment.user.login }}
+    secrets:
+      CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+
+  pi:
+    needs: [parse, check-membership]
+    if: |
+      needs.check-membership.outputs.is_member == 'true' &&
+      (needs.parse.outputs.command == 'review' || needs.parse.outputs.command == 'pi')
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    uses: ./.github/workflows/pi-pr-review.yml
+    with:
+      pr_number: ${{ github.event.issue.number }}
+      extra_prompt: ${{ needs.parse.outputs.extra_prompt }}
+      triggered_by: ${{ github.event.comment.user.login }}
+    secrets:
+      DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ Session.vim
 
 .history
 .direnv
+
+# Local Claude Code settings (user-specific)
+.claude/settings.local.json

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,61 @@
+# Pull request review — shared policy
+
+You are reviewing a GitHub pull request for the **windmill-labs/windmill-helm-charts** repository. Apply this policy alongside your tool's output requirements.
+
+This repo packages the official Helm chart for [Windmill](https://github.com/windmill-labs/windmill). Reviews should focus on Helm/Kubernetes correctness and on user-facing breakage.
+
+## Verdict (first line of the review)
+
+Start every review with a single verdict line, before any other section. Pick exactly one:
+
+- **Good to merge** — no blocking issues and no nits worth surfacing.
+- **Mergeable, but should ideally address nits: <short list>** — no blockers, but P2 findings that are worth a look. The list must name each nit briefly.
+- **Should address issues before merging: <short list>** — at least one P0 or P1 finding. The list must name each blocking issue briefly.
+
+The names in the list must match findings detailed later in the review. Do not invent items that aren't in the body, and do not bury blockers in the body without surfacing them in the verdict.
+
+## Review policy
+
+- Only report issues you are confident are real and introduced by this pull request.
+- Focus on Helm/K8s correctness, security defaults, and user-facing breakage.
+- Do not report style nits, speculative concerns, pre-existing issues, or anything obvious from a `helm lint` / `helm template` run.
+- Self-validate each finding before posting: "is this definitely a real issue?" If uncertain, discard it.
+- Read additional files only when the diff is not enough to validate a finding.
+- Do not modify any files.
+
+## Severity triage
+
+Tag each finding with a severity. Always report P0 and P1. Report P2 only when the diff invites it (a new template, a new top-level value key, a meaningful default change).
+
+- **P0** — secrets in committed files, RBAC/PSA escalation a user did not opt into, NetworkPolicy that fully exposes previously isolated traffic, broken auth/TLS defaults, accidental deletion of persistent storage on upgrade.
+- **P1** — silent breaking change to existing installations on `helm upgrade` (renamed value with no `lookup` fallback, removed default that users depend on, switched StatefulSet `volumeClaimTemplate` storageClass/size in place, label/selector changes that orphan workloads), incorrect template rendering producing invalid manifests for common configurations, missing or wrong dependency `version` / `repository`.
+- **P2** — `values.yaml` documentation drift (key documented but not used, or used but undocumented), inconsistent indentation, missing `helpers.tpl` reuse, naming that contradicts behavior, `appVersion` not bumped alongside `version`.
+
+## Checklist for chart changes
+
+For any change that touches `charts/windmill/`, verify:
+
+- (a) **Chart.yaml versioning** — chart `version` is bumped on any rendered-output change; `appVersion` is bumped when the underlying Windmill image tag changes. The `chart-releaser-action` only republishes when `version` changes, so a forgotten bump means the change never ships.
+- (b) **Backward compatibility on `helm upgrade`** — renaming or moving a value in `values.yaml` is a breaking change unless the template still honors the old key (use a `lookup` / fallback or document the migration in `CHANGELOG.md`).
+- (c) **Selector immutability** — `Deployment` / `StatefulSet` `spec.selector.matchLabels` and `Service` `spec.selector` cannot be changed in place on existing clusters. Flag any diff that touches these.
+- (d) **Persistent data safety** — changes to PVC names, `volumeClaimTemplates`, or storage class/size on existing StatefulSets can orphan or destroy user data. Flag any such change as P0 unless the PR explicitly handles migration.
+- (e) **Security defaults** — flipping `privileged`, `allowPrivilegeEscalation`, `runAsNonRoot`, `readOnlyRootFilesystem`, host networking, or removing a NetworkPolicy is sensitive. The `CHANGELOG.md` should call out the change and motivation.
+- (f) **Documentation** — every new top-level key in `values.yaml` has a comment describing what it does and the safe default. Keys removed from `values.yaml` are also removed from `README.md`.
+
+## Test coverage assessment
+
+End your review with a short "Test coverage" section. The repo's CI runs `helm lint` and `helm template` (see `.github/workflows/helm_test.yml`), so mention only what's beyond that:
+
+- For non-trivial template logic, expect a `helm template` invocation in the PR description showing the rendered output for at least the default and one toggled-on configuration.
+- For breaking changes, expect a `CHANGELOG.md` entry under the matching major version.
+- For dependency bumps (`minio`, etc.), expect verification that the new subchart still renders against the existing values.
+
+If the PR is doc-only or CI-only, say so plainly.
+
+## Additional reviewer instructions
+
+If the prompt or context includes an "Additional reviewer instructions" section, treat it as extra guidance from the human who triggered this review and follow it.
+
+## Prior PR discussion
+
+If the prompt or context includes a "Prior PR discussion" section, this PR has already received review activity. Look for your own previous comment, take it into account, focus on what changed in the latest commits, and do not repeat findings the human already pushed back on or addressed.


### PR DESCRIPTION
## Summary

Mirror the automated PR review system from \`windmill-labs/windmill\` here. Same three reviewers (Claude, Codex/GPT-5, Pi/DeepSeek) auto-run on PRs and can be re-triggered with slash commands.

## Changes

### Review policy
- \`REVIEW.md\` — shared review policy, **adapted for Helm chart context**: focuses on Chart.yaml versioning, \`helm upgrade\` backward compat, selector immutability, persistent-data safety on StatefulSets, security defaults (\`privileged\`, NetworkPolicy, etc.), and \`values.yaml\` documentation drift. Drops the Rust/Svelte-specific sections from the windmill repo's REVIEW.md.

### Workflows
- \`pr-ready-review.yml\` — Claude review on PR open / ready_for_review (uses \`anthropics/claude-code-action@v1\`).
- \`codex-pr-review.yml\` — Codex review using \`@openai/codex\` CLI (gpt-5.5).
- \`pi-pr-review.yml\` — Pi review using \`@mariozechner/pi-coding-agent\` (DeepSeek V4 Pro).
- \`pr-review-commands.yml\` — slash-command dispatcher: \`/review\` runs all three, \`/claude\` / \`/codex\` / \`/pi\` run a single reviewer. Optional extra prompt on subsequent lines.
- \`check-org-membership.yml\` — gates the above so only \`windmill-labs\` org members (and \`windmill-internal-app[bot]\`) can trigger reviews.

### Tool prompt files
- \`.claude/review-prompt.md\` — Claude output format (inline comments + summary).
- \`.github/codex/pr-review.prompt.md\` — Codex output format.
- \`.github/pi/pr-review.prompt.md\` — Pi output format.

### Differences vs. the windmill repo

- All EE-related steps are stripped (no \`backend/ee-repo-ref.txt\`, no \`substitute_ee_code.sh\`, no \`WINDMILL_EE_PRIVATE_ACCESS\` secret) — this repo is fully public.
- \`runs-on: ubicloud-standard-2\` → \`runs-on: ubuntu-latest\` to match the existing workflows here.
- Dropped \`SQLX_OFFLINE\` env var (no Rust here).

## Required org/repo secrets

For the auto-reviews to actually run, the following secrets need to be set on \`windmill-labs/windmill-helm-charts\` (same names as in the windmill repo, so they can be copied across):

- \`ORG_ACCESS_TOKEN\` — for org-membership gating. **Required** for any review to fire.
- \`CLAUDE_CODE_OAUTH_TOKEN\` — Claude review.
- \`CODEX_AUTH_JSON\` — Codex review (silently skipped if missing).
- \`DEEPSEEK_API_KEY\` — Pi review (silently skipped if missing).

Each reviewer is independently gated — a missing secret silently skips that reviewer rather than failing the workflow.

## Test plan

- [ ] After merge, copy the four secrets above from \`windmill-labs/windmill\` to \`windmill-labs/windmill-helm-charts\` (org-level secrets work too).
- [ ] Open a small follow-up PR and confirm Claude/Codex/Pi each post a \`## … Review\` comment with severity tags.
- [ ] On that PR, comment \`/codex\` (then \`/pi\`, \`/claude\`, \`/review\`) and verify each command triggers the expected reviewer(s) and gets an :eyes: reaction.
- [ ] Open a PR from a non-org-member account (or a fork) and verify the reviews do not run.