### PR TITLE
Add initContainers/extraContainers hooks to hub and indexer

### DIFF
--- a/charts/windmill/templates/hub.yaml
+++ b/charts/windmill/templates/hub.yaml
@@ -36,8 +36,15 @@ spec:
       {{ if .Values.windmill.imagePullSecrets }}
       imagePullSecrets:
       - name: {{ .Values.windmill.imagePullSecrets }}
-      {{ end }}       
+      {{ end }}
+      {{- if .Values.hub.initContainers }}
+      initContainers:
+      {{- toYaml .Values.hub.initContainers | nindent 6 }}
+      {{- end }}
       containers:
+      {{- with .Values.hub.extraContainers }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       - name: windmill-hub
         securityContext:
       {{- with .Values.hub.containerSecurityContext }}

--- a/charts/windmill/templates/indexer.yaml
+++ b/charts/windmill/templates/indexer.yaml
@@ -39,6 +39,10 @@ spec:
       imagePullSecrets:
       - name: {{ .Values.windmill.imagePullSecrets }}
       {{ end }}
+      {{- if .Values.windmill.indexer.initContainers }}
+      initContainers:
+      {{- toYaml .Values.windmill.indexer.initContainers | nindent 6 }}
+      {{- end }}
       containers:
       {{- with .Values.windmill.indexer.extraContainers }}
       {{- toYaml . | nindent 6 }}

--- a/charts/windmill/values.yaml
+++ b/charts/windmill/values.yaml
@@ -482,6 +482,9 @@ windmill:
     # -- Extra sidecar containers
     extraContainers: []
 
+    # -- Extra init containers
+    initContainers: []
+
     # -- Extra environment variables to apply to the pods
     extraEnv: []
 
@@ -705,6 +708,12 @@ hub:
       memory: "2Gi"
   # -- Extra environment variables to apply to the pods
   extraEnv: []
+
+  # -- Extra sidecar containers
+  extraContainers: []
+
+  # -- Extra init containers
+  initContainers: []
 
   # -- volumes
   volumes: []


### PR DESCRIPTION
## Summary
- Add `initContainers` support to `indexer.yaml`, matching the pattern in `app.yaml` and `worker-groups.yaml`.
- Add both `initContainers` and `extraContainers` support to `hub.yaml`, which previously had no extensibility hooks.
- Expose `windmill.indexer.initContainers`, `hub.initContainers`, and `hub.extraContainers` in `values.yaml` (default `[]`).

Enables ephemeral-secret patterns (init container materializes a Secret like `DATABASE_URL` from an external secret store, sidecar cleans it up after pod startup) on these two remaining templates so they're consistent with `app` and `worker-groups`.

## Test plan
- [x] `helm lint charts/windmill` passes.
- [x] `helm template` with defaults — output unchanged for hub and indexer (no stray empty blocks).
- [x] `helm template` with `hub.initContainers`, `hub.extraContainers`, and `windmill.indexer.initContainers` set — blocks render in the correct positions under the pod spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)