### PR TITLE
hub: allow overriding PUBLIC_APP_URL and PUBLIC_APP_ACCESSIBLE_URL

### DIFF
--- a/charts/windmill/Chart.yaml
+++ b/charts/windmill/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
   - condition: minio.enabled
     name: minio
     repository: https://charts.min.io/
-    version: 5.4.0 # Latest stable version
+    version: 5.4.0  # Latest stable version
 deprecated: false
 description: Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 home: https://www.windmill.dev/

--- a/charts/windmill/Chart.yaml
+++ b/charts/windmill/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: windmill
 type: application
-version: 4.0.150
+version: 4.0.151
 appVersion: 1.699.0
 dependencies:
   - condition: minio.enabled

--- a/charts/windmill/templates/hub.yaml
+++ b/charts/windmill/templates/hub.yaml
@@ -77,7 +77,11 @@ spec:
         - name: PUBLIC_PRIVATE_HUB
           value: "true"
         - name: PUBLIC_APP_URL
-          value: "{{ .Values.windmill.baseProtocol }}://{{ .Values.windmill.baseDomain }}"
+          value: "{{ .Values.hub.appUrl | default (printf "%s://%s" .Values.windmill.baseProtocol .Values.windmill.baseDomain) }}"
+        {{- if .Values.hub.appAccessibleUrl }}
+        - name: PUBLIC_APP_ACCESSIBLE_URL
+          value: "{{ .Values.hub.appAccessibleUrl }}"
+        {{- end }}
         {{ if .Values.hub.apiSecretSecretName }}
         - name: "API_SECRET"
           valueFrom:

--- a/charts/windmill/values.yaml
+++ b/charts/windmill/values.yaml
@@ -675,6 +675,10 @@ hub:
   baseDomain: hub.windmill
   # -- protocol as shown in browser, change to https etc based on your endpoint/ingress configuration, this variable and `baseDomain` are used as part of the BASE_URL environment variable in app and worker container
   baseProtocol: http
+  # -- URL the hub uses for server-side requests to the Windmill app (PUBLIC_APP_URL). Defaults to `{windmill.baseProtocol}://{windmill.baseDomain}`. Set to an internal cluster URL (e.g. `http://windmill-app:8000`) to avoid TLS validation issues when the external ingress uses a self-signed certificate.
+  appUrl: ""
+  # -- URL the hub renders in the browser for links pointing back to the Windmill app (PUBLIC_APP_ACCESSIBLE_URL). When unset, the hub falls back to `appUrl`. Set this to your external URL when `appUrl` is an internal cluster URL.
+  appAccessibleUrl: ""
   # -- name of the secret storing the API secret, take precedence over apiSecret
   apiSecretSecretName: ""
   # -- name of the key in secret storing the API secret. The default key of the api secret is 'apiSecret'


### PR DESCRIPTION
## Summary
- Adds `hub.appUrl` (sets `PUBLIC_APP_URL`) and `hub.appAccessibleUrl` (sets `PUBLIC_APP_ACCESSIBLE_URL`) so the hub's server-side fetches and browser-facing links can use different URLs.
- Lets operators point the hub at an internal cluster URL (e.g. `http://windmill-app:8000`) for server-side calls while keeping browser links on the external ingress — removes the need for `NODE_TLS_REJECT_UNAUTHORIZED=0` when the ingress uses a self-signed certificate.
- Defaults are unchanged: `PUBLIC_APP_URL` still falls back to `{windmill.baseProtocol}://{windmill.baseDomain}`, and `PUBLIC_APP_ACCESSIBLE_URL` is only emitted when set.

## Why
Reported by a customer hosting a private hub behind a self-signed ingress: the hub's Node-side fetch to `/api/users/whoami` failed TLS validation, surfacing as "Hub not available" in the Windmill UI even though the hyperlink worked. The hub source uses two URLs by design — `PUBLIC_APP_URL` server-side and `PUBLIC_APP_ACCESSIBLE_URL` (with fallback) client-side — but the chart only exposed the external URL.

## Example
```yaml
hub:
  enabled: true
  appUrl: http://windmill-app:8000
  appAccessibleUrl: https://windmill.example.com
```

## Test plan
- [x] `helm template` with no overrides: emits only `PUBLIC_APP_URL=http://windmill` (unchanged)
- [x] `helm template` with `hub.appUrl` only: emits the overridden `PUBLIC_APP_URL`, no `PUBLIC_APP_ACCESSIBLE_URL`
- [x] `helm template` with both values set: emits both env vars with the configured values

🤖 Generated with [Claude Code](https://claude.com/claude-code)