### PR TITLE
hub: set serviceAccountName on pod spec via hub.serviceAccount.name

### DIFF
--- a/charts/windmill/templates/hub.yaml
+++ b/charts/windmill/templates/hub.yaml
@@ -33,6 +33,7 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:
+      serviceAccountName: {{ default (include "windmill.serviceAccountName" .) .Values.hub.serviceAccount.name }}
       {{ if .Values.windmill.imagePullSecrets }}
       imagePullSecrets:
       - name: {{ .Values.windmill.imagePullSecrets }}

--- a/charts/windmill/values.yaml
+++ b/charts/windmill/values.yaml
@@ -686,6 +686,10 @@ hub:
   # -- API secret for the hub. Optional, only set if you want to restrict access to the hub.
   apiSecret: ""
 
+  serviceAccount:
+    # -- Name of an existing ServiceAccount to use for the hub pods. If empty, falls back to the chart's main ServiceAccount (see `serviceAccount` at the top level). Set this to bind a dedicated SA for IRSA (EKS) / Workload Identity (GKE).
+    name: ""
+
   # -- Annotations to apply to the pods
   annotations: {}
   # -- Annotations to apply to the pods


### PR DESCRIPTION
## Summary
- Adds `serviceAccountName` to the hub Deployment pod spec, matching `app.yaml`'s behavior.
- Introduces `hub.serviceAccount.name` for binding a dedicated ServiceAccount to hub pods. Falls back to the chart's main `windmill.serviceAccountName` when unset.

## Motivation
Customer request: clusters using IRSA (AWS EKS) or Workload Identity (GKE) need pod-level cloud permissions bound to a specific ServiceAccount on the hub pods. Currently hub pods fall back to the namespace `default` SA regardless of configuration.

## Test plan
- [x] `helm template ... --set hub.enabled=true` renders `serviceAccountName: <release>-windmill` (chart's main SA) by default
- [x] `helm template ... --set hub.enabled=true --set hub.serviceAccount.name=my-hub-sa` renders `serviceAccountName: my-hub-sa`

🤖 Generated with [Claude Code](https://claude.com/claude-code)