### PR TITLE
Guard .spec.replicas when autoscaling is enabled (fix SSA/HPA conflict)

### DIFF
--- a/charts/windmill/templates/app.yaml
+++ b/charts/windmill/templates/app.yaml
@@ -10,7 +10,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  {{- if not (dig "autoscaling" "enabled" false (.Values.windmill.app | default dict)) }}
   replicas: {{ .Values.windmill.appReplicas }}
+  {{- end }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/charts/windmill/templates/autoscaling.yaml
+++ b/charts/windmill/templates/autoscaling.yaml
@@ -12,7 +12,7 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: windmill-{{ $comp }}
-  minReplicas: {{ $values.replicas }}
+  minReplicas: {{ $values.replicas | default (index $.Values.windmill (printf "%sReplicas" $comp)) | default 1 }}
   maxReplicas: {{ $values.autoscaling.maxReplicas }}
   targetCPUUtilizationPercentage: {{ $values.autoscaling.targetCPUUtilizationPercentage }}
 {{- end }}

--- a/charts/windmill/templates/hub.yaml
+++ b/charts/windmill/templates/hub.yaml
@@ -10,7 +10,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}    
 spec:
+  {{- if not (dig "autoscaling" "enabled" false (.Values.hub | default dict)) }}
   replicas: {{ .Values.hub.replicas }}
+  {{- end }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/charts/windmill/templates/indexer.yaml
+++ b/charts/windmill/templates/indexer.yaml
@@ -10,7 +10,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  {{- if not (dig "autoscaling" "enabled" false (.Values.windmill.indexer | default dict)) }}
   replicas: 1
+  {{- end }}
   revisionHistoryLimit: 3
   strategy:
     type: RollingUpdate

--- a/charts/windmill/templates/operator.yaml
+++ b/charts/windmill/templates/operator.yaml
@@ -10,7 +10,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  {{- if not (dig "autoscaling" "enabled" false (.Values.windmill.operator | default dict)) }}
   replicas: {{ .Values.windmill.operator.replicas }}
+  {{- end }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/charts/windmill/templates/windmill-extra.yaml
+++ b/charts/windmill/templates/windmill-extra.yaml
@@ -10,7 +10,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  {{- if not (dig "autoscaling" "enabled" false (.Values.windmill.extra | default dict)) }}
   replicas: {{ .Values.windmill.extraReplicas }}
+  {{- end }}
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
Fixes #543

## Problem

Every Deployment template rendered `spec.replicas` unconditionally, while `autoscaling.yaml` creates an HPA targeting the same Deployment. Under Helm 3's client-side apply this was last-write-wins and went unnoticed. Under **Helm 4's default server-side apply**, once the HPA controller writes to `/scale`, every subsequent `helm upgrade` fails:

```
Error: UPGRADE FAILED: conflict occurred while applying object ...
apps/v1, Kind=Deployment: Apply failed with 1 conflict:
conflict with "..." with subresource "scale": .spec.replicas
```

While fixing this I found a **related bug**: the `app` HPA rendered an empty `minReplicas:` because `autoscaling.yaml` reads `$values.replicas` (`.Values.windmill.app.replicas`), but app's replica count actually lives at `.Values.windmill.appReplicas`.

## Changes

- **Guard `.spec.replicas`** in `app`, `windmill-extra`, `hub`, `operator`, and `indexer` so the chart yields the field to the HPA when that component's `autoscaling.enabled` is true.
  - Uses `dig "autoscaling" "enabled" false (… | default dict)` rather than a direct `.autoscaling.enabled` lookup, because most components don't declare an `autoscaling` key in `values.yaml` and the direct form fails with a nil-pointer error (verified).
- **Fix `minReplicas`** in `autoscaling.yaml`: now resolves `<comp>Replicas` (e.g. `appReplicas`), falls back to `$values.replicas` (e.g. operator), then `1`.

## Verification

- `helm lint` passes.
- Autoscaling **off** (default): all deployments keep `replicas` — no regression.
- App autoscaling **on**: `windmill-app` Deployment emits no `replicas`; HPA gets `minReplicas: 2` (was empty before).
- operator/indexer autoscaling **on**: no nil errors, deployments drop `replicas`, HPAs render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)