### PR TITLE
Allow controller-level annotations for worker groups

### DIFF
--- a/charts/windmill/Chart.yaml
+++ b/charts/windmill/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: windmill
 type: application
-version: 4.0.157
+version: 4.0.158
 appVersion: 1.704.1
 dependencies:
   - condition: minio.enabled

--- a/charts/windmill/templates/worker-groups.yaml
+++ b/charts/windmill/templates/worker-groups.yaml
@@ -13,6 +13,10 @@ metadata:
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}
     workerGroup: {{ $v.name }}
+{{- with $v.deploymentAnnotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   replicas: {{ $v.replicas }}
   {{- if eq $controllerType "Deployment" }}

--- a/charts/windmill/values.yaml
+++ b/charts/windmill/values.yaml
@@ -100,6 +100,9 @@ windmill:
       # -- Annotations to apply to the pods
       annotations: {}
 
+      # -- Annotations to apply to the controller (Deployment/StatefulSet) itself
+      deploymentAnnotations: {}
+
       # -- If a job is being ran, the container will wait for it to finish before terminating until this grace period
       terminationGracePeriodSeconds: 604800
 
@@ -185,6 +188,9 @@ windmill:
       replicas: 1
       # -- Annotations to apply to the pods
       annotations: {}
+
+      # -- Annotations to apply to the controller (Deployment/StatefulSet) itself
+      deploymentAnnotations: {}
 
       # -- Labels to apply to the pods
       labels: {}


### PR DESCRIPTION
## Context

Customer request: allow adding annotations at the **deployment level** for worker groups (e.g. `karpenter.sh/do-not-disrupt`). Previously `worker-groups.yaml` only exposed `annotations` on the **pod template** (`$v.annotations`) — there was no way to set annotations on the Deployment/StatefulSet object itself.

Ref: https://github.com/windmill-labs/windmill-helm-charts/blob/f2173a64060ad3017bc3611e39ca66ceee8a9843/charts/windmill/templates/worker-groups.yaml#L7-L15

## Changes

- `templates/worker-groups.yaml`: render a new `$v.deploymentAnnotations` map into the controller (Deployment/StatefulSet) `metadata.annotations`, gated by `with` so nothing is emitted when unset.
- `values.yaml`: document `deploymentAnnotations: {}` for the example worker groups.
- `Chart.yaml`: bump chart version `4.0.157` → `4.0.158` (chart-only change, `appVersion` unchanged).

A distinct key (`deploymentAnnotations`) is used rather than overloading the existing `$v.annotations`, since that already maps to the pod template metadata — reusing it would silently relocate existing users' pod annotations.

## Verification

`helm template` with `deploymentAnnotations` set renders them under the Deployment `metadata.annotations`; unset (default) emits no `annotations:` key on the controller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)