### PR TITLE
Add explicit REQUIRE_SIGNED_MULTIPLAYER_REQUESTS knob to windmill-extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,8 @@ windmill:
     enableDebugger: true
     # -- require signed debug requests (JWT tokens for debug sessions)
     requireSignedDebugRequests: true
+    # -- require signed multiplayer requests (JWT tokens for collaborative editing sessions). Keep enabled in production.
+    requireSignedMultiplayerRequests: true
 
   # Use those to override the tag or image used for the app and worker containers. Windmill uses the same image for both.
   # By default, if enterprise is enable, the image is set to ghcr.io/windmill-labs/windmill-ee, otherwise the image is set to ghcr.io/windmill-labs/windmill
@@ -359,6 +361,7 @@ enterprise:
 | windmill.windmillExtra.enableLsp                                | bool   | `true`                                                                                     | enable LSP (Language Server Protocol) for code completion                                                                                                                                                        |
 | windmill.windmillExtra.enableDebugger                           | bool   | `true`                                                                                     | enable Debugger for debugging scripts                                                                                                                                                                            |
 | windmill.windmillExtra.requireSignedDebugRequests               | bool   | `true`                                                                                     | require signed debug requests (JWT tokens for debug sessions)                                                                                                                                                    |
+| windmill.windmillExtra.requireSignedMultiplayerRequests         | bool   | `true`                                                                                     | require signed multiplayer requests (JWT tokens for collaborative editing sessions). Keep enabled in production.                                                                                                 |
 | windmill.windmillExtra.affinity                                 | object | `{}`                                                                                       | Affinity rules to apply to the pods                                                                                                                                                                              |
 | windmill.windmillExtra.annotations                              | object | `{}`                                                                                       | Annotations to apply to the pods                                                                                                                                                                                 |
 | windmill.windmillExtra.labels                                   | object | `{}`                                                                                       | Labels to apply to the pods                                                                                                                                                                                      |

--- a/charts/windmill/README.md
+++ b/charts/windmill/README.md
@@ -181,6 +181,7 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.windmillExtra.nodeSelector | object | `{}` | Node selector to use for scheduling the pods |
 | windmill.windmillExtra.podSecurityContext | object | `{"runAsNonRoot":false,"runAsUser":0}` | Security context to apply to the pods |
 | windmill.windmillExtra.requireSignedDebugRequests | bool | `true` | require signed debug requests (JWT tokens for debug sessions) |
+| windmill.windmillExtra.requireSignedMultiplayerRequests | bool | `true` | require signed multiplayer requests (JWT tokens for collaborative editing sessions). Keep enabled in production. |
 | windmill.windmillExtra.resources | object | `{"limits":{"memory":"1Gi"}}` | Resource limits and requests for the pods |
 | windmill.windmillExtra.securityContext | object | `{}` | legacy, use podSecurityContext instead |
 | windmill.windmillExtra.service.annotations | object | `{}` | Annotations to apply to the service |

--- a/charts/windmill/templates/windmill-extra.yaml
+++ b/charts/windmill/templates/windmill-extra.yaml
@@ -71,6 +71,8 @@ spec:
           value: {{ .Values.enterprise.nsjail | quote }}
         - name: REQUIRE_SIGNED_DEBUG_REQUESTS
           value: {{ .Values.windmill.windmillExtra.requireSignedDebugRequests | quote }}
+        - name: REQUIRE_SIGNED_MULTIPLAYER_REQUESTS
+          value: {{ .Values.windmill.windmillExtra.requireSignedMultiplayerRequests | quote }}
         - name: WINDMILL_BASE_URL
           value: "{{ .Values.windmill.windmillExtra.windmillBaseUrl | default "http://windmill-app:8000" }}"
         {{- with .Values.windmill.windmillExtra.extraEnv }}

--- a/charts/windmill/values.yaml
+++ b/charts/windmill/values.yaml
@@ -583,6 +583,9 @@ windmill:
     # -- require signed debug requests (JWT tokens for debug sessions)
     requireSignedDebugRequests: true
 
+    # -- require signed multiplayer requests (JWT tokens for collaborative editing sessions). Keep enabled in production.
+    requireSignedMultiplayerRequests: true
+
     # -- override WINDMILL_BASE_URL for the extra container (defaults to http://windmill-app:8000).
     # -- Set to your external URL (e.g. "https://windmill.example.com") if the debugger fails with token verification errors.
     windmillBaseUrl: ""


### PR DESCRIPTION
## What

Adds an explicit `windmill.windmillExtra.requireSignedMultiplayerRequests` value (default `true`) that wires `REQUIRE_SIGNED_MULTIPLAYER_REQUESTS` into the `windmill-extra` deployment, mirroring the existing `requireSignedDebugRequests` / `REQUIRE_SIGNED_DEBUG_REQUESTS` pattern.

## Why

The multiplayer (Y.js) server defaults to requiring signed requests (`multiplayer/server.mjs`: `process.env.REQUIRE_SIGNED_MULTIPLAYER_REQUESTS !== 'false'`), but the chart never set the env var — it relied implicitly on the source-side default. This makes the secure setting explicit and tamper-evident in rendered manifests.

Default behavior is unchanged on a fresh install (still `true`).

## Note

This is **hardening**, not a fix for any reported authorization issue in the multiplayer service — that requires code changes in the windmill repo (path-scoped JWT claims + ACL checks). No helm value can address that.

## Changes
- `values.yaml`: new `requireSignedMultiplayerRequests: true`
- `templates/windmill-extra.yaml`: emit `REQUIRE_SIGNED_MULTIPLAYER_REQUESTS`
- README docs updated (root + chart)

No chart version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)