### PR TITLE
docs(security): warn that exposeHostDocker exposes the host Docker socket

### DIFF
--- a/charts/windmill/README.md
+++ b/charts/windmill/README.md
@@ -138,7 +138,7 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.databaseUrlSecretKey | string | `"url"` | name of the key in existing secret storing the database URI. The default key of the url is 'url' |
 | windmill.databaseUrlSecretName | string | `""` | name of the existing secret storing the database URI, take precedence over databaseUrl. |
 | windmill.disableUnsharePid | bool | `false` | Some systems like Bottlerocket AMI have max_user_namespaces=0 which prevents unshare from working. |
-| windmill.exposeHostDocker | bool | `false` | mount the docker socket inside the container to be able to run docker command as docker client to the host docker daemon |
+| windmill.exposeHostDocker | bool | `false` | SECURITY RISK: mounts the host node's Docker socket into the worker, giving any user who can run a script root-equivalent control of the node's Docker daemon (and typically the cluster). Trusted, single-tenant use only — never enable for untrusted or multi-tenant workloads. Prefer a dedicated docker worker group with the rootless podman runtime (CONTAINER_RUNTIME=podman on a *-full image, run as a non-root user) instead. |
 | windmill.extraReplicas | int | `1` | replicas for the lsp smart assistant (not required but useful for the web IDE) |
 | windmill.hostAliases | list | `[]` | host aliases for all pods (can be overridden by individual worker groups) |
 | windmill.image | string | `""` | windmill image tag, will use the Acorresponding ee or ce image from ghcr if not defined. Do not include tag in the image name. |
@@ -195,7 +195,7 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.workerGroups[0].disableUnsharePid | bool | `false` | Set to true for nodes where user namespaces are disabled (e.g., Bottlerocket AMI with max_user_namespaces=0). |
 | windmill.workerGroups[0].dnsConfig | object | `{}` | Custom DNS configuration for the pods. Useful for pods with VPN sidecars that need to resolve external DNS names |
 | windmill.workerGroups[0].dnsPolicy | string | `""` | DNS policy for the pods. Set to "None" when using custom dnsConfig (e.g., for VPN sidecars or custom DNS resolution) |
-| windmill.workerGroups[0].exposeHostDocker | bool | `false` | mount the docker socket inside the container to be able to run docker command as docker client to the host docker daemon |
+| windmill.workerGroups[0].exposeHostDocker | bool | `false` | SECURITY RISK: mounts the host node's Docker socket into this worker group, giving any script author root-equivalent control of the node's Docker daemon. Trusted, single-tenant use only. Prefer the rootless podman runtime (CONTAINER_RUNTIME=podman on a *-full image, non-root) instead. |
 | windmill.workerGroups[0].extraContainers | list | `[]` | Extra sidecar containers |
 | windmill.workerGroups[0].extraEnv | list | `[]` | value: "/tmp" |
 | windmill.workerGroups[0].hostAliases | list | `[]` | Host aliases to apply to the pods (overrides global hostAliases if set) |
@@ -221,7 +221,7 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.workerGroups[1].containerSecurityContext | object | `{}` | Security context to apply to the pod |
 | windmill.workerGroups[1].controller | string | `"Deployment"` | Controller to use. Valid options are "Deployment" and "StatefulSet" |
 | windmill.workerGroups[1].disableUnsharePid | bool | `false` | Set to true for nodes where user namespaces are disabled (e.g., Bottlerocket AMI with max_user_namespaces=0). |
-| windmill.workerGroups[1].exposeHostDocker | bool | `false` | mount the docker socket inside the container to be able to run docker command as docker client to the host docker daemon |
+| windmill.workerGroups[1].exposeHostDocker | bool | `false` | SECURITY RISK: mounts the host node's Docker socket into this worker group, giving any script author root-equivalent control of the node's Docker daemon. Trusted, single-tenant use only. Prefer the rootless podman runtime (CONTAINER_RUNTIME=podman on a *-full image, non-root) instead. |
 | windmill.workerGroups[1].extraContainers | list | `[]` | Extra sidecar containers |
 | windmill.workerGroups[1].extraEnv | list | `[{"name":"NUM_WORKERS","value":"8"},{"name":"SLEEP_QUEUE","value":"200"}]` | Extra environment variables to apply to the pods |
 | windmill.workerGroups[1].hostAliases | list | `[]` | Host aliases to apply to the pods (overrides global hostAliases if set) |
@@ -246,7 +246,7 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.workerGroups[2].containerSecurityContext | object | `{}` | Security context to apply to the pod |
 | windmill.workerGroups[2].controller | string | `"Deployment"` | Controller to use. Valid options are "Deployment" and "StatefulSet" |
 | windmill.workerGroups[2].disableUnsharePid | bool | `false` | Set to true for nodes where user namespaces are disabled (e.g., Bottlerocket AMI with max_user_namespaces=0). |
-| windmill.workerGroups[2].exposeHostDocker | bool | `false` | mount the docker socket inside the container to be able to run docker command as docker client to the host docker daemon |
+| windmill.workerGroups[2].exposeHostDocker | bool | `false` | SECURITY RISK: mounts the host node's Docker socket into this worker group, giving any script author root-equivalent control of the node's Docker daemon. Trusted, single-tenant use only. Prefer the rootless podman runtime (CONTAINER_RUNTIME=podman on a *-full image, non-root) instead. |
 | windmill.workerGroups[2].extraContainers | list | `[]` | Extra sidecar containers |
 | windmill.workerGroups[2].extraEnv | list | `[]` | Extra environment variables to apply to the pods |
 | windmill.workerGroups[2].hostAliases | list | `[]` | Host aliases to apply to the pods (overrides global hostAliases if set) |

--- a/charts/windmill/values.yaml
+++ b/charts/windmill/values.yaml
@@ -71,7 +71,7 @@ windmill:
   instanceEventsWebhook: ""
   # -- configure a custom openai base path for azure
   openaiAzureBasePath: ""
-  # -- mount the docker socket inside the container to be able to run docker command as docker client to the host docker daemon
+  # -- SECURITY RISK: mounts the host node's Docker socket into the worker, giving any user who can run a script root-equivalent control of the node's Docker daemon (and typically the cluster). Trusted, single-tenant use only — never enable for untrusted or multi-tenant workloads. Prefer a dedicated docker worker group with the rootless podman runtime (CONTAINER_RUNTIME=podman on a *-full image, run as a non-root user) instead.
   exposeHostDocker: false
   # -- rust log level, set to debug for more information etc, sets RUST_LOG environment variable in app and worker container
   rustLog: info
@@ -163,7 +163,7 @@ windmill:
       # -- command override
       command: []
 
-      # -- mount the docker socket inside the container to be able to run docker command as docker client to the host docker daemon
+      # -- SECURITY RISK: mounts the host node's Docker socket into this worker group, giving any script author root-equivalent control of the node's Docker daemon. Trusted, single-tenant use only. Prefer the rootless podman runtime (CONTAINER_RUNTIME=podman on a *-full image, non-root) instead.
       exposeHostDocker: false
 
       topologySpreadConstraints: []
@@ -243,7 +243,7 @@ windmill:
       volumes: []
       volumeMounts: []
 
-      # -- mount the docker socket inside the container to be able to run docker command as docker client to the host docker daemon
+      # -- SECURITY RISK: mounts the host node's Docker socket into this worker group, giving any script author root-equivalent control of the node's Docker daemon. Trusted, single-tenant use only. Prefer the rootless podman runtime (CONTAINER_RUNTIME=podman on a *-full image, non-root) instead.
       exposeHostDocker: false
 
       # -- Volume claim templates. Only applies when controller is "StatefulSet"
@@ -313,7 +313,7 @@ windmill:
       # -- command override
       command: []
 
-      # -- mount the docker socket inside the container to be able to run docker command as docker client to the host docker daemon
+      # -- SECURITY RISK: mounts the host node's Docker socket into this worker group, giving any script author root-equivalent control of the node's Docker daemon. Trusted, single-tenant use only. Prefer the rootless podman runtime (CONTAINER_RUNTIME=podman on a *-full image, non-root) instead.
       exposeHostDocker: false
 
       # -- Volume claim templates. Only applies when controller is "StatefulSet"


### PR DESCRIPTION
## Summary

`exposeHostDocker` (instance-level and per-worker-group) mounts the node's `/var/run/docker.sock` (`hostPath`, `type: Socket`) into the worker. Access to that socket is **root on the node** — anyone who can run a script can `docker run --privileged -v /:/host …`, read every other pod/container on the node, and reach kubelet/service-account credentials (typically → cluster compromise). The worker sandbox doesn't isolate the network, so a docker-mode job reaches it by design.

The values description was neutral (`mount the docker socket inside the container ...`), giving no signal that this is node-root-equivalent. This PR makes it a clear **SECURITY RISK** warning and points to the safer alternative.

It defaults to `false`, and this is a **comment/description-only** change — no rendered template or behavior change.

## Changes

- `values.yaml`: reframe the `exposeHostDocker` description (instance + all 3 example worker groups) as a security warning — trusted single-tenant use only, never untrusted/multi-tenant.
- `README.md`: sync the helm-docs values table rows.

(No `Chart.yaml` version bump — comments only, no template change.)

## Recommended alternative (pointer)

The warnings point operators at the **rootless podman container runtime** (windmill core PR windmill-labs/windmill#9434): run docker-mode jobs on a dedicated worker group with `CONTAINER_RUNTIME=podman` on a `*-full` image, as a non-root user — no privileged daemon, no network-reachable root socket. That can already be configured today via per-group `extraEnv` + `securityContext`; first-class helm support (the `/dev/fuse` device + non-root defaults) is a sensible follow-up once #9434 lands.

## Note

The README values table is helm-docs-generated; I updated the affected rows by hand to match `values.yaml`. If CI regenerates via `helm-docs`, output should be identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)