### PR TITLE
Support configuring workerGroups as a dict keyed by name

### DIFF
--- a/charts/windmill/Chart.yaml
+++ b/charts/windmill/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: windmill
 type: application
-version: 4.0.170
+version: 4.0.171
 appVersion: 1.717.1
 dependencies:
   - condition: minio.enabled

--- a/charts/windmill/templates/worker-groups.yaml
+++ b/charts/windmill/templates/worker-groups.yaml
@@ -1,4 +1,20 @@
-{{- range $v := .Values.windmill.workerGroups }}
+{{- /*
+workerGroups can be configured either as a list (the primary, documented form)
+or as a dict/map keyed by the worker group name (handy for kustomize overlays,
+where merging into a keyed map avoids having to redefine the whole list).
+Normalize both into a list of objects that each carry a `name` field.
+*/ -}}
+{{- $workerGroups := .Values.windmill.workerGroups }}
+{{- if kindIs "map" $workerGroups }}
+{{- $asList := list }}
+{{- range $name, $group := $workerGroups }}
+{{- $group = default dict $group }}
+{{- $_ := set $group "name" (default $name $group.name) }}
+{{- $asList = append $asList $group }}
+{{- end }}
+{{- $workerGroups = $asList }}
+{{- end }}
+{{- range $v := $workerGroups }}
 {{ if and $v.replicas (ge (int $v.replicas) 0)}}
 ---
 {{- $controllerType := include "validateControllerKind" $v.controller }}

--- a/charts/windmill/values.yaml
+++ b/charts/windmill/values.yaml
@@ -89,6 +89,16 @@ windmill:
   disableUnsharePid: false
 
   # worker groups
+  # NOTE: workerGroups may be provided either as a list (the form documented below)
+  # or as a dict/map keyed by the worker group name, e.g.:
+  #   workerGroups:
+  #     default:
+  #       replicas: 3
+  #     native:
+  #       replicas: 1
+  # The dict form is convenient for kustomize overlays, since it lets you patch a
+  # single group by key instead of redefining the whole list. When using the dict
+  # form, the key is used as the worker group name (an explicit `name` still wins).
   workerGroups:
     # workers configuration
     # The default worker group


### PR DESCRIPTION
## What

`windmill.workerGroups` can now be configured **either** as a list (the primary, documented form) **or** as a dict/map keyed by the worker group name.

```yaml
windmill:
  workerGroups:
    default:
      replicas: 3
    native:
      replicas: 1
      privileged: false
```

## Why

Requested by a user: the dict form is much friendlier for **kustomize overlays**. With the list form, overriding a single field of one worker group in an overlay requires redefining the entire list. With a keyed dict, you can patch a single group (e.g. `workerGroups.default.replicas`) by key.

The list form remains the primary/documented way — the dict form is an additive convenience.

## How

`templates/worker-groups.yaml` gains a small normalization block that detects a map and converts it into the list the rest of the template already expects. The key becomes the group's `name` (an explicit `name:` still wins). The rest of the template is unchanged.

## Verification (`helm template` / `helm lint`)

- **List form** (default values): renders identically to before.
- **Dict form**: correct Deployments with `name`, `workerGroup` label, and `WORKER_GROUP` env derived from the key.
- **Dict + explicit `name`**: key can differ from the rendered group name (useful for overlay patching).
- `helm lint`: 0 failures.

Note: supplying a dict via `-f values.yaml` produces a harmless Helm coalesce warning (the chart default `workerGroups` is a list); Helm correctly drops the default list and uses the dict. Rendered output is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)