### PR TITLE
Add global and per-component pod DNS overrides

### DIFF
--- a/charts/windmill/README.md
+++ b/charts/windmill/README.md
@@ -1,6 +1,6 @@
 # windmill
 
-![Version: 4.0.38](https://img.shields.io/badge/Version-4.0.38-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.606.1](https://img.shields.io/badge/AppVersion-1.606.1-informational?style=flat-square)
+![Version: 4.0.174](https://img.shields.io/badge/Version-4.0.174-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.721.0](https://img.shields.io/badge/AppVersion-1.721.0-informational?style=flat-square)
 
 Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 
@@ -32,16 +32,21 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | enterprise.licenseKey | string | `""` | enterprise license key. (Recommended to avoid: It is recommended to pass it from the Instance settings UI instead) |
 | enterprise.licenseKeySecretKey | string | `"licenseKey"` | name of the key in secret storing the enterprise license key. The default key is 'licenseKey' |
 | enterprise.licenseKeySecretName | string | `""` | name of the secret storing the enterprise license key, take precedence over licenseKey string. |
-| enterprise.metricsAddr | string | `"true"` | Bind address for metrics server. |
-| enterprise.nsjail | bool | `false` | use nsjail for sandboxing |
+| enterprise.metricsAddr | string | `"true"` | Bind address for metrics server. Sets METRICS_ADDR environment variable. |
+| enterprise.nsjail | bool | `false` | Consider using Amazon Linux 2/2023 AMI or configure Bottlerocket kernel parameters via launch template. |
 | enterprise.s3CacheBucket | string | `""` | S3 bucket to use for dependency cache. Sets S3_CACHE_BUCKET environment variable in worker container |
 | enterprise.samlMetadata | string | `""` | SAML Metadata URL/Content to enable SAML SSO (Can be set in the Instance Settings UI which is the recommended method) |
 | enterprise.scimToken | string | `""` | SCIM token (Can be set in the instance settings UI which is the recommended method) |
 | enterprise.scimTokenSecretKey | string | `"scimToken"` | name of the key in secret storing the SCIM token. The default key of the SCIM token is 'scimToken' |
 | enterprise.scimTokenSecretName | string | `""` | name of the secret storing the SCIM token, takes precedence over SCIM token string. |
 | extraDeploy | list | `[]` | Support for deploying additional arbitrary resources. Use for External Secrets, etc. |
+| httproute.appParentRefs | list | `[]` | override parentRefs for the windmill app httproute (falls back to parentRefs) |
 | httproute.enabled | bool | `false` | enable/disable creation of a httproute resource (experimental) |
-| httproute.parentRefs | list | `[]` |  |
+| httproute.hubParentRefs | list | `[]` | override parentRefs for the windmill hub httproute (falls back to parentRefs) |
+| httproute.parentRefs | list | `[]` | default parentRefs for all httproutes |
+| httproute.publicAppDomainParentRefs | list | `[]` | override parentRefs for the publicAppDomain httproute (falls back to parentRefs) |
+| httproute.secondaryApiDomainParentRefs | list | `[]` | override parentRefs for the secondaryApiDomain httproute (falls back to parentRefs) |
+| httproute.secondaryBaseDomainParentRefs | list | `[]` | override parentRefs for the secondaryBaseDomain httproute (falls back to parentRefs) |
 | hub-postgresql.auth.database | string | `"windmillhub"` |  |
 | hub-postgresql.auth.postgresPassword | string | `"windmill"` |  |
 | hub-postgresql.auth.postgresUser | string | `"postgres"` |  |
@@ -57,6 +62,8 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | hub.apiSecret | string | `""` | API secret for the hub. Optional, only set if you want to restrict access to the hub. |
 | hub.apiSecretSecretKey | string | `"apiSecret"` | name of the key in secret storing the API secret. The default key of the api secret is 'apiSecret' |
 | hub.apiSecretSecretName | string | `""` | name of the secret storing the API secret, take precedence over apiSecret |
+| hub.appAccessibleUrl | string | `""` | URL the hub renders in the browser for links pointing back to the Windmill app (PUBLIC_APP_ACCESSIBLE_URL). When unset, the hub falls back to `appUrl`. Set this to your external URL when `appUrl` is an internal cluster URL. |
+| hub.appUrl | string | `""` | URL the hub uses for server-side requests to the Windmill app (PUBLIC_APP_URL). Defaults to `{windmill.baseProtocol}://{windmill.baseDomain}`. Set to an internal cluster URL (e.g. `http://windmill-app:8000`) to avoid TLS validation issues when the external ingress uses a self-signed certificate. |
 | hub.baseDomain | string | `"hub.windmill"` | you also need to set the cookieDomain to the root domain in the app configuration |
 | hub.baseProtocol | string | `"http"` | protocol as shown in browser, change to https etc based on your endpoint/ingress configuration, this variable and `baseDomain` are used as part of the BASE_URL environment variable in app and worker container |
 | hub.containerSecurityContext | object | `{}` |  |
@@ -64,9 +71,13 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | hub.databaseUrl | string | `"postgres://postgres:windmill@windmill-hub-postgresql/windmillhub?sslmode=disable"` | Postgres URI, pods will crashloop if database is unreachable, sets DATABASE_URL environment variable in app and worker container |
 | hub.databaseUrlSecretKey | string | `"url"` | name of the key in secret storing the database URI. The default key of the url is 'url' |
 | hub.databaseUrlSecretName | string | `""` | name of the secret storing the database URI, take precedence over databaseUrl. |
+| hub.dnsConfig | object | `{}` | Custom DNS configuration for the pods. Falls back to windmill.dnsConfig when unset |
+| hub.dnsPolicy | string | `""` | DNS policy for the pods. Valid options are "ClusterFirst", "Default", "ClusterFirstWithHostNet", "None". Falls back to windmill.dnsPolicy when unset |
 | hub.enabled | bool | `false` | enable Windmill Hub, requires Windmill Enterprise and license key |
+| hub.extraContainers | list | `[]` | Extra sidecar containers |
 | hub.extraEnv | list | `[]` | Extra environment variables to apply to the pods |
 | hub.image | string | `""` | image |
+| hub.initContainers | list | `[]` | Extra init containers |
 | hub.labels | object | `{}` | Annotations to apply to the pods |
 | hub.licenseKey | string | `""` | enterprise license key, deprecated use the enterprise values instead |
 | hub.nodeSelector | object | `{}` | Node selector to use for scheduling the pods |
@@ -76,7 +87,8 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | hub.replicas | int | `1` | replicas for the hub |
 | hub.resources | object | `{"limits":{"memory":"2Gi"}}` | Resource limits and requests for the pods |
 | hub.securityContext | string | `nil` | legacy, use podSecurityContext instead |
-| hub.tag | string | `"1.0.7"` |  |
+| hub.serviceAccount.name | string | `""` | Name of an existing ServiceAccount to use for the hub pods. If empty, falls back to the chart's main ServiceAccount (see `serviceAccount` at the top level). Set this to bind a dedicated SA for IRSA (EKS) / Workload Identity (GKE). |
+| hub.tag | string | `"1.2.0"` |  |
 | hub.tolerations | list | `[]` | Tolerations to apply to the pods |
 | hub.volumeMounts | list | `[]` | volumeMounts |
 | hub.volumes | list | `[]` | volumes |
@@ -110,6 +122,8 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.app.autoscaling.maxReplicas | int | `10` | maximum autoscaler replicas |
 | windmill.app.autoscaling.targetCPUUtilizationPercentage | int | `80` | target CPU utilization |
 | windmill.app.containerSecurityContext | object | `{}` |  |
+| windmill.app.dnsConfig | object | `{}` | Custom DNS configuration for the pods. Falls back to windmill.dnsConfig when unset |
+| windmill.app.dnsPolicy | string | `""` | DNS policy for the pods. Valid options are "ClusterFirst", "Default", "ClusterFirstWithHostNet", "None". Falls back to windmill.dnsPolicy when unset |
 | windmill.app.extraContainers | list | `[]` | Extra sidecar containers |
 | windmill.app.extraEnv | list | `[]` | Extra environment variables to apply to the pods |
 | windmill.app.hostAliases | list | `[]` | Host aliases to apply to the pods (overrides global hostAliases if set) |
@@ -125,6 +139,25 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.app.smtpService | object | `{"annotations":{},"enabled":false}` | smtp service configuration for email triggers |
 | windmill.app.smtpService.annotations | object | `{}` | annotations to apply to the service |
 | windmill.app.smtpService.enabled | bool | `false` | whether to expose the smtp port of the app using a load balancer service |
+| windmill.app.smtpTls | object | `{"acme":{"dnsProvider":"dns_cf","dnsSecretName":"","domain":"","enabled":false,"image":"neilpang/acme.sh","imageTag":"latest","keyLength":2048,"nodeSelector":{},"renewBeforeDays":30,"resources":{"limits":{"cpu":"200m","memory":"128Mi"},"requests":{"cpu":"50m","memory":"64Mi"}},"schedule":"0 3 * * *","server":"https://acme-v02.api.letsencrypt.org/directory","tolerations":[]},"certSecretKey":"tls.crt","certSecretName":"","enabled":false,"keySecretKey":"tls.key"}` | SMTP TLS certificate configuration for the inbound email server (port 2525). Mount a TLS certificate from a Kubernetes Secret so acme.sh / cert-manager issued certs are used instead of the auto-generated self-signed certificate. The private key must be in PKCS#8 PEM format (openssl pkcs8 -topk8 -nocrypt -in key.pem -out key_pkcs8.pem). Certificates are hot-reloaded from disk every 12 hours (no restart needed on renewal). |
+| windmill.app.smtpTls.acme | object | `{"dnsProvider":"dns_cf","dnsSecretName":"","domain":"","enabled":false,"image":"neilpang/acme.sh","imageTag":"latest","keyLength":2048,"nodeSelector":{},"renewBeforeDays":30,"resources":{"limits":{"cpu":"200m","memory":"128Mi"},"requests":{"cpu":"50m","memory":"64Mi"}},"schedule":"0 3 * * *","server":"https://acme-v02.api.letsencrypt.org/directory","tolerations":[]}` | Automated certificate issuance/renewal via acme.sh with DNS-01 challenge. Stores the cert in the same K8s Secret referenced by certSecretName above. |
+| windmill.app.smtpTls.acme.dnsProvider | string | `"dns_cf"` | acme.sh DNS plugin name (e.g., dns_cf, dns_aws, dns_gd) |
+| windmill.app.smtpTls.acme.dnsSecretName | string | `""` | name of an existing Secret containing DNS provider credentials (e.g., CF_Token, CF_Zone_ID) |
+| windmill.app.smtpTls.acme.domain | string | `""` | domain to issue the certificate for (e.g., mx.example.com) |
+| windmill.app.smtpTls.acme.enabled | bool | `false` | enable the acme.sh CronJob for automatic cert issuance/renewal |
+| windmill.app.smtpTls.acme.image | string | `"neilpang/acme.sh"` | acme.sh container image |
+| windmill.app.smtpTls.acme.imageTag | string | `"latest"` | acme.sh container image tag |
+| windmill.app.smtpTls.acme.keyLength | int | `2048` | RSA key length for the certificate |
+| windmill.app.smtpTls.acme.nodeSelector | object | `{}` | node selector for the CronJob pod |
+| windmill.app.smtpTls.acme.renewBeforeDays | int | `30` | only renew when fewer than this many days remain before expiry |
+| windmill.app.smtpTls.acme.resources | object | `{"limits":{"cpu":"200m","memory":"128Mi"},"requests":{"cpu":"50m","memory":"64Mi"}}` | resource limits and requests for the CronJob pod |
+| windmill.app.smtpTls.acme.schedule | string | `"0 3 * * *"` | cron schedule for the renewal check (default: daily at 03:00 UTC) |
+| windmill.app.smtpTls.acme.server | string | `"https://acme-v02.api.letsencrypt.org/directory"` | ACME server URL (default: Let's Encrypt production) |
+| windmill.app.smtpTls.acme.tolerations | list | `[]` | tolerations for the CronJob pod |
+| windmill.app.smtpTls.certSecretKey | string | `"tls.crt"` | key in the Secret for the certificate PEM file |
+| windmill.app.smtpTls.certSecretName | string | `""` | name of the Kubernetes Secret containing the certificate and key |
+| windmill.app.smtpTls.enabled | bool | `false` | enable mounting a TLS certificate for the SMTP server |
+| windmill.app.smtpTls.keySecretKey | string | `"tls.key"` | key in the Secret for the private key PEM file (must be PKCS#8 format) |
 | windmill.app.tolerations | list | `[]` | Tolerations to apply to the pods |
 | windmill.app.topologySpreadConstraints | list | `[]` | Topology spread constraints |
 | windmill.app.volumeMounts | list | `[]` |  |
@@ -138,8 +171,10 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.databaseUrlSecretKey | string | `"url"` | name of the key in existing secret storing the database URI. The default key of the url is 'url' |
 | windmill.databaseUrlSecretName | string | `""` | name of the existing secret storing the database URI, take precedence over databaseUrl. |
 | windmill.disableUnsharePid | bool | `false` | Some systems like Bottlerocket AMI have max_user_namespaces=0 which prevents unshare from working. |
+| windmill.dnsConfig | object | `{}` | DNS configuration for all Windmill pods. When dnsPolicy is "None", nameservers must include at least one resolver. Per-component dnsConfig replaces this value entirely (no deep merge) |
+| windmill.dnsPolicy | string | `""` | DNS policy for all Windmill pods (app, workers, indexer, operator, extra, hub). Valid options are "ClusterFirst", "Default", "ClusterFirstWithHostNet", "None". Can be overridden per component or per worker group |
 | windmill.exposeHostDocker | bool | `false` | mount the docker socket inside the container to be able to run docker command as docker client to the host docker daemon |
-| windmill.extraReplicas | int | `1` | replicas for the lsp smart assistant (not required but useful for the web IDE) |
+| windmill.extraReplicas | int | `1` | replicas for windmill-extra (LSP, Multiplayer, Debugger). Set to 0 to disable. |
 | windmill.hostAliases | list | `[]` | host aliases for all pods (can be overridden by individual worker groups) |
 | windmill.image | string | `""` | windmill image tag, will use the Acorresponding ee or ce image from ghcr if not defined. Do not include tag in the image name. |
 | windmill.imagePullPolicy | string | `"Always"` | image pull policy for the app, worker, lsp and multiplayer containers |
@@ -147,9 +182,12 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.indexer.affinity | object | `{}` | Affinity rules to apply to the pods |
 | windmill.indexer.annotations | object | `{}` | Annotations to apply to the pods |
 | windmill.indexer.containerSecurityContext | object | `{}` |  |
+| windmill.indexer.dnsConfig | object | `{}` | Custom DNS configuration for the pods. Falls back to windmill.dnsConfig when unset |
+| windmill.indexer.dnsPolicy | string | `""` | DNS policy for the pods. Valid options are "ClusterFirst", "Default", "ClusterFirstWithHostNet", "None". Falls back to windmill.dnsPolicy when unset |
 | windmill.indexer.enabled | bool | `true` | enable or disable indexer |
 | windmill.indexer.extraContainers | list | `[]` | Extra sidecar containers |
 | windmill.indexer.extraEnv | list | `[]` | Extra environment variables to apply to the pods |
+| windmill.indexer.initContainers | list | `[]` | Extra init containers |
 | windmill.indexer.labels | object | `{}` | Annotations to apply to the pods |
 | windmill.indexer.nodeSelector | object | `{}` | Node selector to use for scheduling the pods |
 | windmill.indexer.podSecurityContext | object | `{"runAsNonRoot":false,"runAsUser":0}` | Security context to apply to the pods |
@@ -162,6 +200,20 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.multiplayerReplicas | int | `1` | replicas for the multiplayer containers used by the app (ee only and ignored if enterprise not enabled) |
 | windmill.npmConfigRegistry | string | `""` | pass the npm for private registries |
 | windmill.openaiAzureBasePath | string | `""` | configure a custom openai base path for azure |
+| windmill.operator.affinity | object | `{}` | Affinity rules to apply to the pods |
+| windmill.operator.annotations | object | `{}` | Annotations to apply to the pods |
+| windmill.operator.containerSecurityContext | object | `{}` | Security context to apply to the container |
+| windmill.operator.dnsConfig | object | `{}` | Custom DNS configuration for the pods. Falls back to windmill.dnsConfig when unset |
+| windmill.operator.dnsPolicy | string | `""` | DNS policy for the pods. Valid options are "ClusterFirst", "Default", "ClusterFirstWithHostNet", "None". Falls back to windmill.dnsPolicy when unset |
+| windmill.operator.enabled | bool | `false` | enable the Windmill Kubernetes operator |
+| windmill.operator.extraContainers | list | `[]` | Extra sidecar containers |
+| windmill.operator.extraEnv | list | `[]` | Extra environment variables to apply to the pods |
+| windmill.operator.labels | object | `{}` | Labels to apply to the pods |
+| windmill.operator.nodeSelector | object | `{}` | Node selector to use for scheduling the pods |
+| windmill.operator.podSecurityContext | object | `{}` | Security context to apply to the pods |
+| windmill.operator.replicas | int | `1` | number of operator replicas (typically 1) |
+| windmill.operator.resources | object | `{"limits":{"memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}}` | Resource limits and requests for the pods |
+| windmill.operator.tolerations | list | `[]` | Tolerations to apply to the pods |
 | windmill.pipExtraIndexUrl | string | `""` | pass the extra index url to pip for private registries |
 | windmill.pipIndexUrl | string | `""` | pass the index url to pip for private registries |
 | windmill.pipTrustedHost | string | `""` | pass the trusted host to pip for private registries |
@@ -173,7 +225,10 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.windmillExtra.affinity | object | `{}` | Affinity rules to apply to the pods |
 | windmill.windmillExtra.annotations | object | `{}` | Annotations to apply to the pods |
 | windmill.windmillExtra.containerSecurityContext | object | `{}` | Security context to apply to the container |
+| windmill.windmillExtra.dnsConfig | object | `{}` | Custom DNS configuration for the pods. Falls back to windmill.dnsConfig when unset |
+| windmill.windmillExtra.dnsPolicy | string | `""` | DNS policy for the pods. Valid options are "ClusterFirst", "Default", "ClusterFirstWithHostNet", "None". Falls back to windmill.dnsPolicy when unset |
 | windmill.windmillExtra.enableDebugger | bool | `true` | enable Debugger for debugging scripts |
+| windmill.windmillExtra.enableGateway | bool | `true` | enable Gateway reverse proxy (routes /ws/*, /ws_mp/*, /ws_debug/* via a single port) |
 | windmill.windmillExtra.enableLsp | bool | `true` | enable LSP (Language Server Protocol) for code completion |
 | windmill.windmillExtra.extraEnv | list | `[]` | Extra environment variables to apply to the pods |
 | windmill.windmillExtra.image | string | `""` | custom image (defaults to ghcr.io/windmill-labs/windmill-extra) |
@@ -187,14 +242,16 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.windmillExtra.service.annotations | object | `{}` | Annotations to apply to the service |
 | windmill.windmillExtra.tag | string | `""` | custom image tag (defaults to the App version) |
 | windmill.windmillExtra.tolerations | list | `[]` | Tolerations to apply to the pods |
+| windmill.windmillExtra.windmillBaseUrl | string | `""` | Set to your external URL (e.g. "https://windmill.example.com") if the debugger fails with token verification errors. |
 | windmill.workerGroups[0].affinity | object | `{}` | Affinity rules to apply to the pods |
 | windmill.workerGroups[0].annotations | object | `{}` | Annotations to apply to the pods |
 | windmill.workerGroups[0].command | list | `[]` | command override |
 | windmill.workerGroups[0].containerSecurityContext | object | `{}` | Security context to apply to the pod |
 | windmill.workerGroups[0].controller | string | `"Deployment"` | Controller to use. Valid options are "Deployment" and "StatefulSet" |
+| windmill.workerGroups[0].deploymentAnnotations | object | `{}` | Annotations to apply to the controller (Deployment/StatefulSet) itself |
 | windmill.workerGroups[0].disableUnsharePid | bool | `false` | Set to true for nodes where user namespaces are disabled (e.g., Bottlerocket AMI with max_user_namespaces=0). |
-| windmill.workerGroups[0].dnsConfig | object | `{}` | Custom DNS configuration for the pods. Useful for pods with VPN sidecars that need to resolve external DNS names |
-| windmill.workerGroups[0].dnsPolicy | string | `""` | DNS policy for the pods. Set to "None" when using custom dnsConfig (e.g., for VPN sidecars or custom DNS resolution) |
+| windmill.workerGroups[0].dnsConfig | object | `{}` | Useful for pods with VPN sidecars that need to resolve external DNS names. Falls back to windmill.dnsConfig when unset |
+| windmill.workerGroups[0].dnsPolicy | string | `""` | Set to "None" when using custom dnsConfig (e.g., for VPN sidecars or custom DNS resolution). Falls back to windmill.dnsPolicy when unset |
 | windmill.workerGroups[0].exposeHostDocker | bool | `false` | mount the docker socket inside the container to be able to run docker command as docker client to the host docker daemon |
 | windmill.workerGroups[0].extraContainers | list | `[]` | Extra sidecar containers |
 | windmill.workerGroups[0].extraEnv | list | `[]` | value: "/tmp" |
@@ -210,6 +267,7 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.workerGroups[0].privileged | bool | `true` | Needed to use proper OOM killer on k8s v1.32+ and use unshare pid for security reasons. |
 | windmill.workerGroups[0].replicas | int | `3` |  |
 | windmill.workerGroups[0].resources | object | `{"limits":{"memory":"2Gi"}}` | Resource limits and requests for the pods |
+| windmill.workerGroups[0].serviceAccountName | string | `""` | Falls back to the global service account when not set. |
 | windmill.workerGroups[0].terminationGracePeriodSeconds | int | `604800` | If a job is being ran, the container will wait for it to finish before terminating until this grace period |
 | windmill.workerGroups[0].tolerations | list | `[]` | Tolerations to apply to the pods |
 | windmill.workerGroups[0].topologySpreadConstraints | list | `[]` |  |
@@ -220,10 +278,11 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.workerGroups[1].annotations | object | `{}` | Annotations to apply to the pods |
 | windmill.workerGroups[1].containerSecurityContext | object | `{}` | Security context to apply to the pod |
 | windmill.workerGroups[1].controller | string | `"Deployment"` | Controller to use. Valid options are "Deployment" and "StatefulSet" |
+| windmill.workerGroups[1].deploymentAnnotations | object | `{}` | Annotations to apply to the controller (Deployment/StatefulSet) itself |
 | windmill.workerGroups[1].disableUnsharePid | bool | `false` | Set to true for nodes where user namespaces are disabled (e.g., Bottlerocket AMI with max_user_namespaces=0). |
 | windmill.workerGroups[1].exposeHostDocker | bool | `false` | mount the docker socket inside the container to be able to run docker command as docker client to the host docker daemon |
 | windmill.workerGroups[1].extraContainers | list | `[]` | Extra sidecar containers |
-| windmill.workerGroups[1].extraEnv | list | `[{"name":"NUM_WORKERS","value":"8"},{"name":"SLEEP_QUEUE","value":"200"}]` | Extra environment variables to apply to the pods |
+| windmill.workerGroups[1].extraEnv | list | `[{"name":"NATIVE_MODE","value":"true"},{"name":"SLEEP_QUEUE","value":"200"}]` | Extra environment variables to apply to the pods |
 | windmill.workerGroups[1].hostAliases | list | `[]` | Host aliases to apply to the pods (overrides global hostAliases if set) |
 | windmill.workerGroups[1].labels | object | `{}` | Labels to apply to the pods |
 | windmill.workerGroups[1].mode | string | `"worker"` |  |
@@ -235,6 +294,7 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.workerGroups[1].privileged | bool | `false` | Not needed for native workers as they use a different memory management and isolation mechanism. |
 | windmill.workerGroups[1].replicas | int | `1` |  |
 | windmill.workerGroups[1].resources | object | `{"limits":{"memory":"2Gi"}}` | Resource limits and requests for the pods |
+| windmill.workerGroups[1].serviceAccountName | string | `""` | Falls back to the global service account when not set. |
 | windmill.workerGroups[1].tolerations | list | `[]` | Tolerations to apply to the pods |
 | windmill.workerGroups[1].topologySpreadConstraints | list | `[]` |  |
 | windmill.workerGroups[1].volumeClaimTemplates | list | `[]` | Volume claim templates. Only applies when controller is "StatefulSet" |
@@ -260,6 +320,7 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.workerGroups[2].privileged | bool | `true` | Needed to use proper OOM killer on k8s v1.32+ and use unshare pid for security reasons. |
 | windmill.workerGroups[2].replicas | int | `0` |  |
 | windmill.workerGroups[2].resources | object | `{"limits":{"memory":"2Gi"}}` | Resource limits and requests for the pods |
+| windmill.workerGroups[2].serviceAccountName | string | `""` | Falls back to the global service account when not set. |
 | windmill.workerGroups[2].tolerations | list | `[]` | Tolerations to apply to the pods |
 | windmill.workerGroups[2].topologySpreadConstraints | list | `[]` |  |
 | windmill.workerGroups[2].volumeClaimTemplates | list | `[]` | Volume claim templates. Only applies when controller is "StatefulSet" |

--- a/charts/windmill/templates/_helpers.tpl
+++ b/charts/windmill/templates/_helpers.tpl
@@ -75,6 +75,34 @@ Validate controller kind, defaulting to "Deployment"
 {{- end -}}
 
 {{/*
+Optional pod DNS settings. Component values fall back to the global
+windmill.dnsPolicy / windmill.dnsConfig values. Emits nothing when neither is set.
+Usage:
+{{- with include "windmill.podDns" (dict "root" $ "component" "app" "dnsPolicy" $policy "dnsConfig" $config) }}
+{{ . | indent 6 }}
+{{- end }}
+*/}}
+{{- define "windmill.podDns" -}}
+{{- $root := .root -}}
+{{- $component := .component | default "pod" -}}
+{{- $dnsPolicy := default $root.Values.windmill.dnsPolicy .dnsPolicy -}}
+{{- $dnsConfig := default dict (default $root.Values.windmill.dnsConfig .dnsConfig) -}}
+{{- if and (eq $dnsPolicy "None") (not $dnsConfig.nameservers) -}}
+{{- fail (printf "windmill: %s: dnsPolicy \"None\" requires dnsConfig.nameservers" $component) -}}
+{{- end -}}
+{{- $dns := dict -}}
+{{- if $dnsPolicy -}}
+{{- $_ := set $dns "dnsPolicy" $dnsPolicy -}}
+{{- end -}}
+{{- if $dnsConfig -}}
+{{- $_ := set $dns "dnsConfig" $dnsConfig -}}
+{{- end -}}
+{{- if $dns -}}
+{{- toYaml $dns -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Renders a value that contains a template, with scope if present.
 Usage:
 {{ include "common.tplvalues.render" (dict "value" . "context" $) }}

--- a/charts/windmill/templates/app.yaml
+++ b/charts/windmill/templates/app.yaml
@@ -38,6 +38,9 @@ spec:
     spec:
       terminationGracePeriodSeconds: 40
       serviceAccountName: {{ template "windmill.serviceAccountName" . }}
+      {{- with include "windmill.podDns" (dict "root" $ "component" "app" "dnsPolicy" .Values.windmill.app.dnsPolicy "dnsConfig" .Values.windmill.app.dnsConfig) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       {{ if .Values.windmill.imagePullSecrets }}
       imagePullSecrets:
       - name: {{ .Values.windmill.imagePullSecrets }}

--- a/charts/windmill/templates/hub.yaml
+++ b/charts/windmill/templates/hub.yaml
@@ -37,6 +37,9 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: {{ default (include "windmill.serviceAccountName" .) .Values.hub.serviceAccount.name }}
+      {{- with include "windmill.podDns" (dict "root" $ "component" "hub" "dnsPolicy" .Values.hub.dnsPolicy "dnsConfig" .Values.hub.dnsConfig) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       {{ if .Values.windmill.imagePullSecrets }}
       imagePullSecrets:
       - name: {{ .Values.windmill.imagePullSecrets }}

--- a/charts/windmill/templates/indexer.yaml
+++ b/charts/windmill/templates/indexer.yaml
@@ -38,6 +38,9 @@ spec:
   {{- end }}
     spec:
       serviceAccountName: {{ template "windmill.serviceAccountName" . }}
+      {{- with include "windmill.podDns" (dict "root" $ "component" "indexer" "dnsPolicy" .Values.windmill.indexer.dnsPolicy "dnsConfig" .Values.windmill.indexer.dnsConfig) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       {{ if .Values.windmill.imagePullSecrets }}
       imagePullSecrets:
       - name: {{ .Values.windmill.imagePullSecrets }}

--- a/charts/windmill/templates/operator.yaml
+++ b/charts/windmill/templates/operator.yaml
@@ -37,6 +37,9 @@ spec:
   {{- end }}
     spec:
       serviceAccountName: {{ template "windmill.serviceAccountName" . }}
+      {{- with include "windmill.podDns" (dict "root" $ "component" "operator" "dnsPolicy" .Values.windmill.operator.dnsPolicy "dnsConfig" .Values.windmill.operator.dnsConfig) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       {{ if .Values.windmill.imagePullSecrets }}
       imagePullSecrets:
       - name: {{ .Values.windmill.imagePullSecrets }}

--- a/charts/windmill/templates/windmill-extra.yaml
+++ b/charts/windmill/templates/windmill-extra.yaml
@@ -36,6 +36,9 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:
+      {{- with include "windmill.podDns" (dict "root" $ "component" "windmill-extra" "dnsPolicy" .Values.windmill.windmillExtra.dnsPolicy "dnsConfig" .Values.windmill.windmillExtra.dnsConfig) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       {{ if .Values.windmill.imagePullSecrets }}
       imagePullSecrets:
       - name: {{ .Values.windmill.imagePullSecrets }}

--- a/charts/windmill/templates/worker-groups.yaml
+++ b/charts/windmill/templates/worker-groups.yaml
@@ -248,12 +248,8 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- if $v.dnsPolicy }}
-      dnsPolicy: {{ $v.dnsPolicy }}
-    {{- end }}
-    {{- with $v.dnsConfig }}
-      dnsConfig:
-{{ toYaml . | indent 8 }}
+    {{- with include "windmill.podDns" (dict "root" $ "component" (printf "workerGroup %s" $v.name) "dnsPolicy" $v.dnsPolicy "dnsConfig" $v.dnsConfig) }}
+      {{- . | nindent 6 }}
     {{- end }}
 {{- if eq $controllerType "StatefulSet" }}
   {{- if $v.volumeClaimTemplates }}

--- a/charts/windmill/values.yaml
+++ b/charts/windmill/values.yaml
@@ -77,6 +77,10 @@ windmill:
   rustLog: info
   # -- host aliases for all pods (can be overridden by individual worker groups)
   hostAliases: []
+  # -- DNS policy for all Windmill pods (app, workers, indexer, operator, extra, hub). Valid options are "ClusterFirst", "Default", "ClusterFirstWithHostNet", "None". Can be overridden per component or per worker group
+  dnsPolicy: ""
+  # -- DNS configuration for all Windmill pods. When dnsPolicy is "None", nameservers must include at least one resolver. Per-component dnsConfig replaces this value entirely (no deep merge)
+  dnsConfig: {}
   # -- domain to use for the public app. Use it for extra security so that custom apps cannot force the user to do custom api call on the main app
   publicAppDomain: ""
   # -- domain to use for the secondary api. Can be useful to have a secondary api domain that bypass a CDN like Cloudflare or similar.
@@ -179,11 +183,11 @@ windmill:
       topologySpreadConstraints: []
 
       # -- DNS policy for the pods. Valid options are "ClusterFirst", "Default", "ClusterFirstWithHostNet", "None"
-      # -- Set to "None" when using custom dnsConfig (e.g., for VPN sidecars or custom DNS resolution)
+      # -- Set to "None" when using custom dnsConfig (e.g., for VPN sidecars or custom DNS resolution). Falls back to windmill.dnsPolicy when unset
       dnsPolicy: ""
 
       # -- Custom DNS configuration for the pods. Only used when dnsPolicy is set to "None"
-      # -- Useful for pods with VPN sidecars that need to resolve external DNS names
+      # -- Useful for pods with VPN sidecars that need to resolve external DNS names. Falls back to windmill.dnsConfig when unset
       dnsConfig: {}
 
       # -- Optional override of the ServiceAccount name for this worker group.
@@ -364,6 +368,10 @@ windmill:
 
     # -- Affinity rules to apply to the pods
     affinity: {}
+    # -- DNS policy for the pods. Valid options are "ClusterFirst", "Default", "ClusterFirstWithHostNet", "None". Falls back to windmill.dnsPolicy when unset
+    dnsPolicy: ""
+    # -- Custom DNS configuration for the pods. Falls back to windmill.dnsConfig when unset
+    dnsConfig: {}
 
     # -- Resource limits and requests for the pods
     resources:
@@ -488,6 +496,10 @@ windmill:
 
     # -- Affinity rules to apply to the pods
     affinity: {}
+    # -- DNS policy for the pods. Valid options are "ClusterFirst", "Default", "ClusterFirstWithHostNet", "None". Falls back to windmill.dnsPolicy when unset
+    dnsPolicy: ""
+    # -- Custom DNS configuration for the pods. Falls back to windmill.dnsConfig when unset
+    dnsConfig: {}
 
     # -- Resource limits and requests for the pods
     resources:
@@ -526,6 +538,10 @@ windmill:
     tolerations: []
     # -- Affinity rules to apply to the pods
     affinity: {}
+    # -- DNS policy for the pods. Valid options are "ClusterFirst", "Default", "ClusterFirstWithHostNet", "None". Falls back to windmill.dnsPolicy when unset
+    dnsPolicy: ""
+    # -- Custom DNS configuration for the pods. Falls back to windmill.dnsConfig when unset
+    dnsConfig: {}
     # -- Security context to apply to the pods
     podSecurityContext: {}
     # -- Security context to apply to the container
@@ -575,6 +591,10 @@ windmill:
 
     # -- Affinity rules to apply to the pods
     affinity: {}
+    # -- DNS policy for the pods. Valid options are "ClusterFirst", "Default", "ClusterFirstWithHostNet", "None". Falls back to windmill.dnsPolicy when unset
+    dnsPolicy: ""
+    # -- Custom DNS configuration for the pods. Falls back to windmill.dnsConfig when unset
+    dnsConfig: {}
 
     # -- Resource limits and requests for the pods
     resources:
@@ -729,6 +749,10 @@ hub:
 
   # -- Affinity rules to apply to the pods
   affinity: {}
+  # -- DNS policy for the pods. Valid options are "ClusterFirst", "Default", "ClusterFirstWithHostNet", "None". Falls back to windmill.dnsPolicy when unset
+  dnsPolicy: ""
+  # -- Custom DNS configuration for the pods. Falls back to windmill.dnsConfig when unset
+  dnsConfig: {}
   # -- Resource limits and requests for the pods
   resources:
     limits:


### PR DESCRIPTION
## Summary

Subsumes #574 — same goal (cluster-wide DNS overrides for Windmill pods), reworked with a few design changes; #574 can be closed in favor of this PR.

- Add `windmill.dnsPolicy` and `windmill.dnsConfig` values applied to all Windmill pods: app, workers, indexer, operator, extra, and hub
- Allow per-component overrides (`windmill.app.*`, `windmill.indexer.*`, `windmill.operator.*`, `windmill.windmillExtra.*`, `hub.*`) in addition to the existing per-worker-group values; all fall back to the global values when unset
- Fail rendering with the offending component name when `dnsPolicy: "None"` is set without any reachable `dnsConfig.nameservers`

### Differences from #574

- **Values live under `windmill.` instead of top-level**, matching the existing convention for settings shared by all Windmill pods (cf. `windmill.imagePullSecrets`, `windmill.hostAliases`) and avoiding ambiguity with the postgres/minio subcharts
- **Whitespace-clean rendering**: the helper builds a dict and `toYaml`s it; call sites use `with`/`nindent`, so charts rendered without DNS values are byte-identical to current main (verified by diff with all components enabled)
- **Per-component overrides** wired through the same helper, not just worker groups
- **Validation error names the component**, e.g. `windmill: workerGroup gpu: dnsPolicy "None" requires dnsConfig.nameservers`
- **README regenerated** with helm-docs (also catches up previously undocumented values: httproute parentRefs overrides, hub appUrl/serviceAccount, smtpTls/acme, etc.)

## Testing

- `helm lint charts/windmill`
- `helm template` with all components enabled and no DNS values → output byte-identical to main
- Global + per-component + per-worker-group overrides rendered and inspected: app/hub/group overrides win, others fall back to global; partial override works (hub `dnsPolicy` set, `dnsConfig` inherited from global)
- `dnsPolicy: "None"` without nameservers fails at global, component, and worker-group level with the component name in the message; passes when global nameservers are inherited
- `--set windmill.dnsConfig=null` renders fine

Chart version bump left out per the usual post-merge bump flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)