### PR TITLE
Guard worker-group .spec.replicas under native autoscaling

### DIFF
--- a/charts/windmill/templates/worker-groups.yaml
+++ b/charts/windmill/templates/worker-groups.yaml
@@ -15,7 +15,7 @@ Normalize both into a list of objects that each carry a `name` field.
 {{- $workerGroups = $asList }}
 {{- end }}
 {{- range $v := $workerGroups }}
-{{ if and $v.replicas (ge (int $v.replicas) 0)}}
+{{ if or $v.autoscalingManaged (and $v.replicas (ge (int $v.replicas) 0)) }}
 ---
 {{- $controllerType := include "validateControllerKind" $v.controller }}
 apiVersion: apps/v1
@@ -35,7 +35,9 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
+  {{- if not $v.autoscalingManaged }}
   replicas: {{ $v.replicas }}
+  {{- end }}
   {{- if eq $controllerType "Deployment" }}
   strategy:
     type: RollingUpdate

--- a/charts/windmill/values.yaml
+++ b/charts/windmill/values.yaml
@@ -111,6 +111,12 @@ windmill:
       controller: "Deployment"
 
       replicas: 3
+      # -- Set to true when this worker group's replica count is managed by Windmill's
+      # -- native Kubernetes autoscaler. The chart then omits spec.replicas so helm
+      # -- upgrades no longer reset the count the autoscaler set (and avoids the
+      # -- server-side apply field-ownership conflict under Helm 4). When true, the
+      # -- `replicas` value above is ignored and the deployment is rendered regardless.
+      autoscalingManaged: false
       # -- Annotations to apply to the pods
       annotations: {}
 
@@ -200,6 +206,12 @@ windmill:
       controller: "Deployment"
 
       replicas: 1
+      # -- Set to true when this worker group's replica count is managed by Windmill's
+      # -- native Kubernetes autoscaler. The chart then omits spec.replicas so helm
+      # -- upgrades no longer reset the count the autoscaler set (and avoids the
+      # -- server-side apply field-ownership conflict under Helm 4). When true, the
+      # -- `replicas` value above is ignored and the deployment is rendered regardless.
+      autoscalingManaged: false
       # -- Annotations to apply to the pods
       annotations: {}
 


### PR DESCRIPTION
## Problem

`worker-groups.yaml` renders `spec.replicas` unconditionally, so every `helm upgrade` resets the replica count set by Windmill's **native** Kubernetes autoscaler (field manager `windmill-native-auto-scaler`), undoing its adjustments. Under Helm 4's default server-side apply, this also surfaces as a field-ownership conflict on `.spec.replicas`.

This is the same class of bug fixed for HPA-managed components (app, hub, operator, indexer, windmill-extra) in #544 — but #544 did not touch worker groups.

## Fix

Add a per-worker-group `autoscalingManaged` flag:

- When `true`, the chart omits `spec.replicas`, yielding the field to the native autoscaler so helm upgrades no longer reset it (and the SSA conflict goes away).
- The outer render guard also honors the flag, so a managed group still renders when `replicas` is unset. The previous guard `and $v.replicas (ge (int $v.replicas) 0)` treats `0`/`nil` as falsy and drops the deployment entirely, so omitting `replicas` wasn't a viable workaround.

Unlike the HPA case in #544 (`autoscaling.enabled`), worker-group autoscaling is native and configured in Windmill itself rather than via a chart-created HPA, so an explicit flag reads more clearly than reusing the `autoscaling.enabled` shape.

## Usage

```yaml
windmill:
  workerGroups:
    - name: native
      autoscalingManaged: true   # replicas managed by Windmill's native autoscaler
```

## Verification (`helm template`)

| group | config | result |
|-------|--------|--------|
| managed | `replicas: 5`, `autoscalingManaged: true` | renders **without** `spec.replicas` |
| normal | `replicas: 3` | renders with `replicas: 3` (unchanged) |
| managed-no-replicas | `autoscalingManaged: true`, no `replicas` | renders without `spec.replicas` |
| zero | `replicas: 0` | omitted entirely (existing behavior preserved) |

No `Chart.yaml` bump — chart/app version is bumped automatically by the release bot, consistent with #544.

🤖 Generated with [Claude Code](https://claude.com/claude-code)