### PR TITLE
feat(worker-groups): support per-worker-group image and tag overrides

### DIFF
--- a/charts/windmill/templates/worker-groups.yaml
+++ b/charts/windmill/templates/worker-groups.yaml
@@ -111,9 +111,9 @@ spec:
         {{ end }}
         {{ end }}
         {{ if $.Values.enterprise.enabled }}
-        image: {{ default "ghcr.io/windmill-labs/windmill-ee" $.Values.windmill.image }}:{{ default $.Chart.AppVersion $.Values.windmill.tag }}
+        image: {{ default (default "ghcr.io/windmill-labs/windmill-ee" $.Values.windmill.image) $v.image }}:{{ default (default $.Chart.AppVersion $.Values.windmill.tag) $v.tag }}
         {{ else }}
-        image: {{ default "ghcr.io/windmill-labs/windmill" $.Values.windmill.image }}:{{ default $.Chart.AppVersion $.Values.windmill.tag }}
+        image: {{ default (default "ghcr.io/windmill-labs/windmill" $.Values.windmill.image) $v.image }}:{{ default (default $.Chart.AppVersion $.Values.windmill.tag) $v.tag }}
         {{ end }}
         imagePullPolicy: {{ default "Always" $.Values.windmill.imagePullPolicy }}
         {{ if $v.command }}

--- a/charts/windmill/values.yaml
+++ b/charts/windmill/values.yaml
@@ -201,6 +201,15 @@ windmill:
       # -- Falls back to the global service account when not set.
       serviceAccountName: ""
 
+      # -- Optional override of the container image for this worker group.
+      # -- Useful for running a custom image (e.g. with pre-installed binaries) on some
+      # -- worker groups while keeping the standard image elsewhere.
+      # -- Falls back to windmill.image when not set.
+      image: ""
+      # -- Optional override of the container image tag for this worker group.
+      # -- Falls back to windmill.tag (then the chart appVersion) when not set.
+      tag: ""
+
     - name: "native"
       # -- Controller to use. Valid options are "Deployment" and "StatefulSet"
       controller: "Deployment"
@@ -281,6 +290,15 @@ windmill:
       # -- Falls back to the global service account when not set.
       serviceAccountName: ""
 
+      # -- Optional override of the container image for this worker group.
+      # -- Useful for running a custom image (e.g. with pre-installed binaries) on some
+      # -- worker groups while keeping the standard image elsewhere.
+      # -- Falls back to windmill.image when not set.
+      image: ""
+      # -- Optional override of the container image tag for this worker group.
+      # -- Falls back to windmill.tag (then the chart appVersion) when not set.
+      tag: ""
+
     - name: "gpu"
       # -- Controller to use. Valid options are "Deployment" and "StatefulSet"
       controller: "Deployment"
@@ -350,6 +368,15 @@ windmill:
       # -- Optional override of the ServiceAccount name for this worker group.
       # -- Falls back to the global service account when not set.
       serviceAccountName: ""
+
+      # -- Optional override of the container image for this worker group.
+      # -- Useful for running a custom image (e.g. with pre-installed binaries) on some
+      # -- worker groups while keeping the standard image elsewhere.
+      # -- Falls back to windmill.image when not set.
+      image: ""
+      # -- Optional override of the container image tag for this worker group.
+      # -- Falls back to windmill.tag (then the chart appVersion) when not set.
+      tag: ""
 
   # app configuration
   app:


### PR DESCRIPTION
## Problem

The Helm chart uses the global `windmill.image` and `windmill.tag` for every worker group (`worker-groups.yaml`). There was no way to set a custom container image per worker group — e.g. to run a custom image with pre-installed binaries on some groups while keeping the standard image for the app and other groups.

## Change

Add optional `image` and `tag` fields to each worker group spec in `values.yaml` (defaulting to empty string), mirroring the existing per-group `serviceAccountName` override pattern.

In `worker-groups.yaml`, the image line now nests the group override outside the global default:

```
image: {{ default (default "ghcr.io/windmill-labs/windmill-ee" $.Values.windmill.image) $v.image }}:{{ default (default $.Chart.AppVersion $.Values.windmill.tag) $v.tag }}
```

(and the equivalent CE branch).

**Precedence for each group:** group `image`/`tag` when set → global `windmill.image`/`windmill.tag` → built-in default image / chart `appVersion`. Defaults are empty strings, so existing deployments render byte-identically.

## Validation

`helm lint` passes. Rendered `helm template` across the matrix:

| Group config | Rendered image |
|---|---|
| no override (CE, default) | `ghcr.io/windmill-labs/windmill:1.750.0` |
| group `image` + `tag` (EE) | `myregistry.io/custom-windmill:v1.2.3` |
| group `tag` only (EE) | `ghcr.io/windmill-labs/windmill-ee:special-tag` |
| no group override (EE) | `ghcr.io/windmill-labs/windmill-ee:1.750.0` |
| global `windmill.image`+`tag`, no group override | `global.io/wm:globaltag` |
| global set + group override | group override wins |

## Notes

- Scope kept to the two files named in the issue (`values.yaml`, `worker-groups.yaml`). The chart `version` bump and the helm-docs-generated `README.md` table are handled by the repo's separate release-bump PRs (the README is already several versions stale in `main`), so they are intentionally left out here to keep the diff focused. Happy to fold in a version bump / README regen if the maintainers prefer it in-PR.

Fixes WIN-2133

🤖 Generated with [Claude Code](https://claude.com/claude-code)