### PR TITLE
fix(helm): remove bare host from httpGet readiness probes (WIN-2188)

### DIFF
--- a/charts/windmill/templates/app.yaml
+++ b/charts/windmill/templates/app.yaml
@@ -99,7 +99,6 @@ spec:
           successThreshold: 1
           failureThreshold: 1
           httpGet:
-            host:
             scheme: HTTP
             path: /
             httpHeaders:

--- a/charts/windmill/templates/indexer.yaml
+++ b/charts/windmill/templates/indexer.yaml
@@ -67,7 +67,6 @@ spec:
           successThreshold: 1
           failureThreshold: 1
           httpGet:
-            host:
             scheme: HTTP
             path: /
             httpHeaders:

--- a/charts/windmill/templates/worker-groups.yaml
+++ b/charts/windmill/templates/worker-groups.yaml
@@ -132,7 +132,6 @@ spec:
           successThreshold: 1
           failureThreshold: 1
           httpGet:
-            host:
             scheme: HTTP
             path: /ready
             port: 8001


### PR DESCRIPTION
## Problem

The readiness probe `httpGet` blocks in `app.yaml`, `indexer.yaml`, and `worker-groups.yaml` contained a bare `host:` key with no value. When rendered, this produces `host: null` in the manifest YAML, which fails strict Kubernetes schema validation.

The `host` field is optional in the Kubernetes API and defaults to the pod IP when omitted, which is the desired behavior.

## Fix

Deleted the bare `host:` line from the `httpGet` block in all three templates:

- `charts/windmill/templates/app.yaml`
- `charts/windmill/templates/indexer.yaml`
- `charts/windmill/templates/worker-groups.yaml`

The separate `httpHeaders` `Host: localhost` entry in app/indexer is untouched — only the empty `host:` field is removed. Probe behavior is unchanged.

## Validation

- `helm lint charts/windmill` → passes.
- `helm template` with indexer and enterprise (worker-groups) enabled → all three readiness probes now render:
  ```yaml
  httpGet:
    scheme: HTTP
    path: /
    ...
  ```
  with no `host: null`. The only remaining `host:` lines in rendered output are legitimate Ingress rule hostnames.

Fixes WIN-2188

🤖 Generated with [Claude Code](https://claude.com/claude-code)