### PR TITLE
fix(helm): null securityContext + HTTPRoute defaults; per-group DB/baseUrl override (WIN-2188)

### DIFF
--- a/charts/windmill/templates/app.yaml
+++ b/charts/windmill/templates/app.yaml
@@ -66,9 +66,9 @@ spec:
       {{- toYaml . | nindent 6 }}
       {{- end }}
       - name: windmill-app
-        securityContext:
       {{- with .Values.windmill.app.containerSecurityContext }}
-      {{- toYaml . | nindent 10 }}
+        securityContext:
+        {{- toYaml . | nindent 10 }}
       {{- end }}
         lifecycle:
           preStop:

--- a/charts/windmill/templates/httproute.yaml
+++ b/charts/windmill/templates/httproute.yaml
@@ -28,8 +28,11 @@ spec:
         value: "/ws_mp/"
     {{- end }}
     backendRefs:
-    - name: windmill-extra
+    - group: ""
+      kind: Service
+      name: windmill-extra
       port: 3000
+      weight: 1
   {{- end }}
   {{ if .Values.enterprise.enabled }}
   {{ if .Values.windmill.indexer.enabled }}
@@ -38,8 +41,11 @@ spec:
         type: PathPrefix
         value: "/api/srch/"
     backendRefs:
-    - name: windmill-indexer
+    - group: ""
+      kind: Service
+      name: windmill-indexer
       port: 8000
+      weight: 1
   {{ end }}
   {{ end }}
   - matches:
@@ -47,8 +53,11 @@ spec:
         type: PathPrefix
         value: "/"
     backendRefs:
-    - name: windmill-app
+    - group: ""
+      kind: Service
+      name: windmill-app
       port: 8000
+      weight: 1
 
 {{ if .Values.windmill.secondaryBaseDomain }}
 ---
@@ -81,8 +90,11 @@ spec:
         value: "/ws_mp/"
     {{- end }}
     backendRefs:
-    - name: windmill-extra
+    - group: ""
+      kind: Service
+      name: windmill-extra
       port: 3000
+      weight: 1
   {{- end }}
   {{ if .Values.enterprise.enabled }}
   {{ if .Values.windmill.indexer.enabled }}
@@ -91,8 +103,11 @@ spec:
         type: PathPrefix
         value: "/api/srch/"
     backendRefs:
-    - name: windmill-indexer
+    - group: ""
+      kind: Service
+      name: windmill-indexer
       port: 8000
+      weight: 1
   {{ end }}
   {{ end }}
   - matches:
@@ -100,8 +115,11 @@ spec:
         type: PathPrefix
         value: "/"
     backendRefs:
-    - name: windmill-app
+    - group: ""
+      kind: Service
+      name: windmill-app
       port: 8000
+      weight: 1
 {{- end }}
 
 {{ if .Values.windmill.secondaryApiDomain }}
@@ -124,8 +142,11 @@ spec:
         type: PathPrefix
         value: "/api/"
     backendRefs:
-    - name: windmill-app
+    - group: ""
+      kind: Service
+      name: windmill-app
       port: 8000
+      weight: 1
 {{- end }}
 {{ if .Values.hub.enabled }}
 ---
@@ -147,8 +168,11 @@ spec:
         type: PathPrefix
         value: "/"
     backendRefs:
-    - name: windmill-hub
+    - group: ""
+      kind: Service
+      name: windmill-hub
       port: 3003
+      weight: 1
 {{- end }}
 {{ if .Values.windmill.publicAppDomain }}
 ---
@@ -170,7 +194,10 @@ spec:
         type: PathPrefix
         value: "/"
     backendRefs:
-    - name: windmill-app
+    - group: ""
+      kind: Service
+      name: windmill-app
       port: 8000
+      weight: 1
 {{- end }}
 {{- end }}

--- a/charts/windmill/templates/hub.yaml
+++ b/charts/windmill/templates/hub.yaml
@@ -53,9 +53,9 @@ spec:
       {{- toYaml . | nindent 6 }}
       {{- end }}
       - name: windmill-hub
-        securityContext:
       {{- with .Values.hub.containerSecurityContext }}
-      {{- toYaml . | nindent 10 }}
+        securityContext:
+        {{- toYaml . | nindent 10 }}
       {{- end }}
         image: {{ default "ghcr.io/windmill-labs/windmillhub-ee-public" .Values.hub.image }}:{{ default "main" .Values.hub.tag }}
         imagePullPolicy: {{ default "Always" $.Values.windmill.imagePullPolicy }}

--- a/charts/windmill/templates/indexer.yaml
+++ b/charts/windmill/templates/indexer.yaml
@@ -54,9 +54,9 @@ spec:
       {{- toYaml . | nindent 6 }}
       {{- end }}
       - name: windmill-indexer
-        securityContext:
       {{- with .Values.windmill.indexer.containerSecurityContext }}
-      {{- toYaml . | nindent 10 }}
+        securityContext:
+        {{- toYaml . | nindent 10 }}
       {{- end }}
         image: {{ default "ghcr.io/windmill-labs/windmill-ee" .Values.windmill.image }}:{{ default .Chart.AppVersion .Values.windmill.tag }}
         imagePullPolicy: {{ default "Always" $.Values.windmill.imagePullPolicy }}

--- a/charts/windmill/templates/operator.yaml
+++ b/charts/windmill/templates/operator.yaml
@@ -49,9 +49,9 @@ spec:
       {{- toYaml . | nindent 6 }}
       {{- end }}
       - name: windmill-operator
-        securityContext:
       {{- with .Values.windmill.operator.containerSecurityContext }}
-      {{- toYaml . | nindent 10 }}
+        securityContext:
+        {{- toYaml . | nindent 10 }}
       {{- end }}
         {{ if .Values.enterprise.enabled }}
         image: {{ default "ghcr.io/windmill-labs/windmill-ee" .Values.windmill.image }}:{{ default .Chart.AppVersion .Values.windmill.tag }}

--- a/charts/windmill/templates/windmill-extra.yaml
+++ b/charts/windmill/templates/windmill-extra.yaml
@@ -45,9 +45,9 @@ spec:
       {{ end }}
       containers:
       - name: windmill-extra
-        securityContext:
       {{- with .Values.windmill.windmillExtra.containerSecurityContext }}
-      {{- toYaml . | nindent 10 }}
+        securityContext:
+        {{- toYaml . | nindent 10 }}
       {{- end }}
         image: {{ default "ghcr.io/windmill-labs/windmill-extra" .Values.windmill.windmillExtra.image }}:{{ default .Chart.AppVersion .Values.windmill.windmillExtra.tag }}
         imagePullPolicy: {{ default "Always" $.Values.windmill.imagePullPolicy }}

--- a/charts/windmill/templates/worker-groups.yaml
+++ b/charts/windmill/templates/worker-groups.yaml
@@ -156,7 +156,13 @@ spec:
         - name : "METRICS_ADDR"
           value: "{{ $.Values.enterprise.metricsAddr }}"
         {{ end }}
-        {{ if $.Values.windmill.databaseSecret }}
+        {{ if $v.databaseUrlSecretName }}
+        - name: "DATABASE_URL"
+          valueFrom:
+            secretKeyRef:
+              name: "{{ $v.databaseUrlSecretName }}"
+              key: "{{ default "url" $v.databaseUrlSecretKey }}"
+        {{ else if $.Values.windmill.databaseSecret }}
         - name: "DATABASE_URL"
           valueFrom:
             secretKeyRef:
@@ -173,7 +179,7 @@ spec:
           value: "{{ $.Values.windmill.databaseUrl }}"
         {{ end }}
         - name: "BASE_URL"
-          value: "{{ $.Values.windmill.baseProtocol }}://{{ $.Values.windmill.baseDomain }}"
+          value: "{{ if $v.baseUrl }}{{ $v.baseUrl }}{{ else }}{{ $.Values.windmill.baseProtocol }}://{{ $.Values.windmill.baseDomain }}{{ end }}"
         - name: "RUST_LOG"
           value: "{{ $.Values.windmill.rustLog }}"
         - name: "MODE"

--- a/charts/windmill/templates/worker-groups.yaml
+++ b/charts/windmill/templates/worker-groups.yaml
@@ -102,12 +102,14 @@ spec:
         securityContext:
           privileged: true
         {{ else }}
+        {{ if or $v.securityContext $v.containerSecurityContext }}
         securityContext:
         {{ with $v.securityContext }}
 {{ toYaml . | indent 10 }}
         {{ end }}
         {{ with $v.containerSecurityContext }}
 {{ toYaml . | indent 10 }}
+        {{ end }}
         {{ end }}
         {{ end }}
         {{ if $.Values.enterprise.enabled }}

--- a/charts/windmill/values.yaml
+++ b/charts/windmill/values.yaml
@@ -210,6 +210,18 @@ windmill:
       # -- Falls back to windmill.tag (then the chart appVersion) when not set.
       tag: ""
 
+      # -- Optional name of an existing secret holding the DATABASE_URL for this
+      # -- worker group. Points a single group at a different Windmill instance's
+      # -- database without running a separate Helm release. When set, it takes
+      # -- precedence over the release-global windmill.databaseSecret and
+      # -- windmill.databaseUrlSecretName.
+      databaseUrlSecretName: ""
+      # -- Key within databaseUrlSecretName holding the database URL. Defaults to "url" when not set.
+      databaseUrlSecretKey: ""
+      # -- Optional override of BASE_URL for this worker group. Falls back to
+      # -- {windmill.baseProtocol}://{windmill.baseDomain} when not set.
+      baseUrl: ""
+
     - name: "native"
       # -- Controller to use. Valid options are "Deployment" and "StatefulSet"
       controller: "Deployment"
@@ -299,6 +311,18 @@ windmill:
       # -- Falls back to windmill.tag (then the chart appVersion) when not set.
       tag: ""
 
+      # -- Optional name of an existing secret holding the DATABASE_URL for this
+      # -- worker group. Points a single group at a different Windmill instance's
+      # -- database without running a separate Helm release. When set, it takes
+      # -- precedence over the release-global windmill.databaseSecret and
+      # -- windmill.databaseUrlSecretName.
+      databaseUrlSecretName: ""
+      # -- Key within databaseUrlSecretName holding the database URL. Defaults to "url" when not set.
+      databaseUrlSecretKey: ""
+      # -- Optional override of BASE_URL for this worker group. Falls back to
+      # -- {windmill.baseProtocol}://{windmill.baseDomain} when not set.
+      baseUrl: ""
+
     - name: "gpu"
       # -- Controller to use. Valid options are "Deployment" and "StatefulSet"
       controller: "Deployment"
@@ -377,6 +401,18 @@ windmill:
       # -- Optional override of the container image tag for this worker group.
       # -- Falls back to windmill.tag (then the chart appVersion) when not set.
       tag: ""
+
+      # -- Optional name of an existing secret holding the DATABASE_URL for this
+      # -- worker group. Points a single group at a different Windmill instance's
+      # -- database without running a separate Helm release. When set, it takes
+      # -- precedence over the release-global windmill.databaseSecret and
+      # -- windmill.databaseUrlSecretName.
+      databaseUrlSecretName: ""
+      # -- Key within databaseUrlSecretName holding the database URL. Defaults to "url" when not set.
+      databaseUrlSecretKey: ""
+      # -- Optional override of BASE_URL for this worker group. Falls back to
+      # -- {windmill.baseProtocol}://{windmill.baseDomain} when not set.
+      baseUrl: ""
 
   # app configuration
   app:


### PR DESCRIPTION
Follow-up to #622 (which removed the bare `host:` from readiness probes), addressing the remaining review comments. Each was reviewed against the templates first; comment #4 was included after judging it low-risk and well-motivated.

## 1. Don't emit `securityContext: null` for containers without a configured context ✅

Container-level `securityContext:` in `app.yaml`, `indexer.yaml`, `operator.yaml`, `hub.yaml`, `windmill-extra.yaml`, and the non-privileged `worker-groups.yaml` branch was emitted **unconditionally**, with only the value wrapped in `{{- with }}`. When `containerSecurityContext` is unset this rendered a literal `securityContext: null`, which strict schema validators (kubeconform, `kubectl --validate=strict`) reject and which shows as a perpetual diff against the server-stored object.

Fix: wrap the whole key inside the `with`/`if` so it's only emitted when a value exists.

```yaml
{{- with .Values.windmill.app.containerSecurityContext }}
  securityContext:
  {{- toYaml . | nindent 10 }}
{{- end }}
```

The **pod-level** `securityContext` blocks were already correctly guarded (`{{- with … }}` wraps the key) and are left unchanged.

## 2. Don't emit `host:` (null) in worker/indexer readiness probes ✅

Already fixed and merged in #622.

## 3. Set `group`/`kind`/`weight` explicitly on HTTPRoute backendRefs ✅

`httproute.yaml` emitted backendRefs with only `name` and `port`. The API server defaults and *stores* `group: ""`, `kind: Service`, `weight: 1`, causing a perpetual diff for GitOps tools (ArgoCD) comparing rendered vs live. Now emits the three defaulted fields explicitly on every backendRef.

## 4. Per-worker-group `databaseUrlSecretName` / `baseUrl` override ✅

Reviewer flagged this as possibly too specific, but it's cleanly additive, follows the per-group image/tag override precedent (#613), and removes a real operational pain (running an entire second Helm release just to point one worker group at a different Windmill instance's database).

New optional per-group values (documented on all three default groups in `values.yaml`):
- `databaseUrlSecretName` (+ `databaseUrlSecretKey`, default `"url"`) — sources `DATABASE_URL` from a group-specific existing secret, taking precedence over the release-global `windmill.databaseSecret` / `windmill.databaseUrlSecretName`.
- `baseUrl` — overrides `BASE_URL` for the group, falling back to `{windmill.baseProtocol}://{windmill.baseDomain}` when unset.

All fields are optional and fall through to existing behavior when unset, so default renders are byte-identical except for the schema-correctness fixes above.

## Validation

- `helm lint charts/windmill` → passes.
- `helm template` with all components enabled (indexer, enterprise, hub, operator, httproute, privileged + non-privileged worker groups) renders; all 17 docs parse under strict YAML and contain **zero** `securityContext: null` / `host: null` fields.
- `kubeconform -strict` → 15 valid, 0 invalid, 2 skipped (Gateway API CRDs, no bundled schema).
- Positive cases verified via `helm template`:
  - container `securityContext` renders when set;
  - HTTPRoute backendRefs render `group`/`kind`/`weight`;
  - per-group `databaseUrlSecretName`/`databaseUrlSecretKey` produce a `secretKeyRef` and `baseUrl` overrides `BASE_URL`.

## Notes

- The helm-docs-generated `README.md` is already stale relative to several prior PRs (e.g. #613's per-group image/tag are undocumented) and its regeneration isn't CI-enforced, so I kept this PR focused on templates + `values.yaml` (source of truth) rather than pulling in unrelated historical drift. Values comments are written so a future `helm-docs` run produces clean descriptions.
- `Chart.yaml` version is intentionally untouched — version bumps land as separate automated release commits.

Fixes WIN-2188

🤖 Generated with [Claude Code](https://claude.com/claude-code)