### PR TITLE
Bump helm version to 1.771.0

### DIFF
--- a/charts/windmill/Chart.yaml
+++ b/charts/windmill/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: windmill
 type: application
-version: 4.0.218
-appVersion: 1.770.0
+version: 4.0.219
+appVersion: 1.771.0
 dependencies:
   - condition: minio.enabled
     name: minio


### PR DESCRIPTION
Bumps appVersion to Windmill [v1.771.0](https://github.com/windmill-labs/windmill/releases/tag/v1.771.0) and chart version to 4.0.219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)