### PR TITLE
feat(helm): render the secondary API domain as its own Ingress

### DIFF
--- a/charts/windmill/Chart.yaml
+++ b/charts/windmill/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: windmill
 type: application
-version: 4.0.225
+version: 4.0.226
 appVersion: 1.777.1
 dependencies:
   - condition: minio.enabled

--- a/charts/windmill/README.md
+++ b/charts/windmill/README.md
@@ -95,6 +95,10 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |
 | ingress.enabled | bool | `true` | enable/disable included ingress resource |
+| ingress.secondaryApi.annotations | object | `{}` | annotations for the API ingress. Replaces `ingress.annotations`, it does not merge with them. |
+| ingress.secondaryApi.className | string | `""` | ingress class for the API ingress. Falls back to `ingress.className`. |
+| ingress.secondaryApi.separateIngress | bool | `false` | render `windmill.secondaryApiDomain` as its own Ingress resource instead of an extra host on the main one. Required to route the API domain through a different ingress class, controller entrypoint or LoadBalancer IP, which is what allows firewalling API traffic separately from UI traffic. The Gateway API path already does this through `httproute.secondaryApiDomainParentRefs`. |
+| ingress.secondaryApi.tls | list | `[]` | TLS config for the API ingress. When empty, entries of `ingress.tls` listing the API domain are carried over. |
 | ingress.tls | list | `[]` | TLS config for the ingress resource. Useful when using cert-manager and nginx-ingress |
 | minio.auth.rootPassword | string | `"windmill"` |  |
 | minio.auth.rootUser | string | `"windmill"` |  |

--- a/charts/windmill/ci/ee-values.yaml
+++ b/charts/windmill/ci/ee-values.yaml
@@ -1,2 +1,15 @@
 enterprise:
   enabled: true
+
+# exercises the separate API ingress, including the carry-over of the matching ingress.tls entry
+windmill:
+  secondaryApiDomain: api.windmill.local
+ingress:
+  tls:
+    - hosts:
+        - windmill.local
+        - api.windmill.local
+      secretName: windmill-tls
+  secondaryApi:
+    separateIngress: true
+    className: nginx

--- a/charts/windmill/templates/ingress.yaml
+++ b/charts/windmill/templates/ingress.yaml
@@ -91,7 +91,7 @@ spec:
                 port:
                   number: 8000
     {{ end }}
-    {{ if .Values.windmill.secondaryApiDomain }}
+    {{ if and .Values.windmill.secondaryApiDomain (not .Values.ingress.secondaryApi.separateIngress) }}
     - host: {{ .Values.windmill.secondaryApiDomain | quote }}
       http:
         paths:
@@ -170,4 +170,57 @@ spec:
                 port:
                   number: 8000
     {{- end }}
+{{- end }}
+{{- if and .Values.ingress.enabled .Values.windmill.secondaryApiDomain .Values.ingress.secondaryApi.separateIngress }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: windmill-api
+{{- with .Values.ingress.secondaryApi.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  {{- with (.Values.ingress.secondaryApi.className | default .Values.ingress.className) }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+{{- if .Values.ingress.secondaryApi.tls }}
+  tls:
+  {{- range .Values.ingress.secondaryApi.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- else if .Values.ingress.tls }}
+  {{- $apiDomain := .Values.windmill.secondaryApiDomain }}
+  {{- $inherited := list }}
+  {{- range .Values.ingress.tls }}
+    {{- if has $apiDomain .hosts }}
+      {{- $inherited = append $inherited . }}
+    {{- end }}
+  {{- end }}
+  {{- if $inherited }}
+  tls:
+  {{- range $inherited }}
+    - hosts:
+        - {{ $apiDomain | quote }}
+      secretName: {{ .secretName }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+  rules:
+    - host: {{ .Values.windmill.secondaryApiDomain | quote }}
+      http:
+        paths:
+          - path: /api/
+            pathType: Prefix
+            backend:
+              service:
+                name: windmill-app
+                port:
+                  number: 8000
 {{- end }}

--- a/charts/windmill/values.yaml
+++ b/charts/windmill/values.yaml
@@ -714,6 +714,16 @@ ingress:
   # -- TLS config for the ingress resource. Useful when using cert-manager and nginx-ingress
   tls: []
 
+  secondaryApi:
+    # -- render `windmill.secondaryApiDomain` as its own Ingress resource instead of an extra host on the main one. Required to route the API domain through a different ingress class, controller entrypoint or LoadBalancer IP, which is what allows firewalling API traffic separately from UI traffic. The Gateway API path already does this through `httproute.secondaryApiDomainParentRefs`.
+    separateIngress: false
+    # -- ingress class for the API ingress. Falls back to `ingress.className`.
+    className: ""
+    # -- annotations for the API ingress. Replaces `ingress.annotations`, it does not merge with them.
+    annotations: {}
+    # -- TLS config for the API ingress. When empty, entries of `ingress.tls` listing the API domain are carried over.
+    tls: []
+
 httproute:
   # -- enable/disable creation of a httproute resource (experimental)
   enabled: false


### PR DESCRIPTION
## Summary

`windmill.secondaryApiDomain` is currently emitted as an extra host inside the single
`windmill` Ingress object, so it necessarily shares that object's `ingressClassName` and
annotations. That makes it impossible to send API traffic through a different ingress
class, controller entrypoint or LoadBalancer IP, which is what a deployment needs in order
to firewall API traffic separately from UI traffic (a DNS-level split between the UI and
the endpoints consumed by third-party systems).

The Gateway API path already does exactly this: `httproute.yaml` renders the API domain as
its own `windmill-secondary-api-domain` HTTPRoute, attachable to a different Gateway via
`httproute.secondaryApiDomainParentRefs`. This PR brings the Ingress path to parity.

Opt-in through `ingress.secondaryApi.separateIngress`, default `false`.

```yaml
ingress:
  className: traefik
  secondaryApi:
    separateIngress: true
    className: traefik-api
    annotations:
      traefik.ingress.kubernetes.io/router.entrypoints: apiweb
```

When enabled, the API host leaves the main Ingress and becomes a standalone `windmill-api`
Ingress with a single `/api/` prefix rule to `windmill-app:8000`.

## Changes

- `templates/ingress.yaml`: the `secondaryApiDomain` host block is now skipped when
  `ingress.secondaryApi.separateIngress` is set, and a second `windmill-api` Ingress is
  rendered instead.
- `values.yaml`: new `ingress.secondaryApi` block (`separateIngress`, `className`,
  `annotations`, `tls`).
- `ci/ee-values.yaml`: enables the new option so `ct install` applies the new object to a
  real cluster, including the TLS carry-over path.
- `README.md`: the four new value rows. (Not a full `helm-docs` regeneration — the
  committed README is several releases stale, and regenerating would bury this change under
  ~30 unrelated rows.)

### Behaviour notes

- `className` falls back to `ingress.className` when unset.
- `annotations` **replaces** `ingress.annotations` rather than merging. That is deliberate:
  the point of the option is a different controller, so inheriting the main object's
  annotations is usually wrong. It also means a cert-manager annotation on the main Ingress
  does not silently drive issuance from two objects at once.
- `tls` falls back to carrying over the entries of `ingress.tls` that list the API domain,
  so flipping `separateIngress` on an existing install is a one-line change and does not
  silently drop the certificate. An explicit `secondaryApi.tls` wins.
- The API host's entry is intentionally left in `ingress.tls` on the main object. A TLS
  entry with no matching rule is ignored by controllers, and removing it would change
  behaviour for anyone relying on the main Ingress to drive issuance.
- Unchanged and out of scope: `/api/srch/` goes to `windmill-indexer` on `baseDomain` but
  to `windmill-app` on the API domain. That is pre-existing. `publicAppDomain` has the same
  single-object limitation and the same block generalises to it if anyone asks.

## Test plan

- [x] `helm lint` clean, with and without the new values.
- [x] **Backward compatibility**: `helm template` output is byte-identical to `main` for
      `ci/oss-values.yaml`, the pre-change `ci/ee-values.yaml`, and a values file setting
      every domain (`baseDomain`, `secondaryApiDomain`, `secondaryBaseDomain`,
      `publicAppDomain`) with `enterprise.enabled`.
- [x] `separateIngress: true` → API host removed from the `windmill` Ingress rules, present
      in a separate `windmill-api` Ingress.
- [x] `secondaryApi.className` unset → inherits `ingress.className`.
- [x] Explicit `secondaryApi.tls` takes precedence over the carry-over.
- [x] `ingress.tls` containing a multi-host entry that includes the API domain → the API
      Ingress gets a TLS entry scoped to the API domain alone, same `secretName`.
- [x] `ingress.tls` with **no** entry for the API domain → no dangling empty `tls:` key.
- [x] `separateIngress: true` with an empty `secondaryApiDomain` → no `windmill-api` object.
- [x] All rendered documents parse as valid `networking.k8s.io/v1` Ingress with well-formed
      rules and TLS entries.
- [ ] CI `ct install` applies the new Ingress to a kind cluster (via `ci/ee-values.yaml`).