### PR TITLE
fix(ci): unblock the AI PR reviewers, which have never run in this repo

### DIFF
--- a/.github/workflows/check-write-access.yml
+++ b/.github/workflows/check-write-access.yml
@@ -1,0 +1,74 @@
+name: Check Write Access
+
+# Authorizes a user to trigger privileged command workflows (/review, /ai, /plan,
+# /updatesqlx, ...). The webhook author_association reports PRIVATE org members as
+# CONTRIBUTOR/NONE (only public members show as MEMBER), so command jobs can't gate on
+# it alone. This mints the internal GitHub App token — which can see private members —
+# and confirms the user is a member or has write access to the repo. The app token is
+# minted fresh per run, so unlike the old ORG_ACCESS_TOKEN PAT it never expires.
+
+on:
+  workflow_call:
+    inputs:
+      username:
+        required: true
+        type: string
+        description: 'The user whose access to verify'
+      trusted_bot:
+        required: false
+        type: string
+        default: 'windmill-internal-app[bot]'
+        description: 'A bot login that is always authorized'
+    outputs:
+      authorized:
+        description: 'true if the user is the trusted bot, an org member, or has repo write access'
+        value: ${{ jobs.check.outputs.authorized }}
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      authorized: ${{ steps.check.outputs.authorized }}
+    steps:
+      # This check is purely additive: callers OR it with author_association, so it must
+      # never fail the job. Failing here would block every dependent reviewer job through
+      # `needs`, turning an unconfigured app into a total review outage rather than a
+      # fallback to the author_association path.
+      - name: Mint internal app token
+        id: app
+        if: vars.INTERNAL_APP_ID != ''
+        continue-on-error: true
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.INTERNAL_APP_ID }}
+          private-key: ${{ secrets.INTERNAL_APP_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Resolve authorization
+        id: check
+        env:
+          # Without the app token, the default token still resolves public members and
+          # repo collaborators; private members simply fall through to author_association.
+          GH_TOKEN: ${{ steps.app.outputs.token || github.token }}
+          USERNAME: ${{ inputs.username }}
+          TRUSTED_BOT: ${{ inputs.trusted_bot }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [ "$USERNAME" = "$TRUSTED_BOT" ]; then
+            echo "authorized=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          ORG="${REPO%%/*}"
+          # Org membership resolves private members too (204 = member, 404 = not).
+          if gh api "orgs/$ORG/members/$USERNAME" --silent 2>/dev/null; then
+            echo "authorized=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Fallback: effective repo permission (also covers outside collaborators).
+          PERM=$(gh api "repos/$REPO/collaborators/$USERNAME/permission" --jq '.permission' 2>/dev/null || echo none)
+          if [ "$PERM" = "admin" ] || [ "$PERM" = "write" ]; then
+            echo "authorized=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "authorized=false" >> "$GITHUB_OUTPUT"
+            echo "$USERNAME is neither the trusted bot, an org member, nor a repo writer."
+          fi

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -31,12 +31,16 @@ jobs:
   codex-review:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # A non-fork PR (head.repo.fork == false) can only be opened by someone with push
+    # access to this repo, so fork==false already enforces write access. Do NOT re-add
+    # an author_association gate: the pull_request webhook payload reports private org
+    # members as CONTRIBUTOR/NONE (only public members show as MEMBER), which silently
+    # skips auto-review for every private member.
     if: |
       github.event_name == 'workflow_call' ||
       (
         github.event.pull_request.draft == false &&
-        github.event.pull_request.head.repo.fork == false &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+        github.event.pull_request.head.repo.fork == false
       )
     permissions:
       contents: read

--- a/.github/workflows/pi-pr-review.yml
+++ b/.github/workflows/pi-pr-review.yml
@@ -31,12 +31,16 @@ jobs:
   pi-review:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # A non-fork PR (head.repo.fork == false) can only be opened by someone with push
+    # access to this repo, so fork==false already enforces write access. Do NOT re-add
+    # an author_association gate: the pull_request webhook payload reports private org
+    # members as CONTRIBUTOR/NONE (only public members show as MEMBER), which silently
+    # skips auto-review for every private member.
     if: |
       github.event_name == 'workflow_call' ||
       (
         github.event.pull_request.draft == false &&
-        github.event.pull_request.head.repo.fork == false &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+        github.event.pull_request.head.repo.fork == false
       )
     permissions:
       contents: read

--- a/.github/workflows/pr-ready-review.yml
+++ b/.github/workflows/pr-ready-review.yml
@@ -30,11 +30,16 @@ concurrency:
 jobs:
   auto-review:
     runs-on: ubuntu-latest
+    # A non-fork PR (head.repo.fork == false) can only be opened by someone with push
+    # access to this repo, so fork==false already enforces write access. Do NOT re-add
+    # an author_association gate: the pull_request webhook payload reports private org
+    # members as CONTRIBUTOR/NONE (only public members show as MEMBER), which silently
+    # skips auto-review for every private member.
     if: |
       github.event_name == 'workflow_call' ||
       (
         (github.event.pull_request.draft == false || github.event.pull_request.ready_for_review == true) &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+        github.event.pull_request.head.repo.fork == false
       )
     permissions:
       contents: read

--- a/.github/workflows/pr-ready-review.yml
+++ b/.github/workflows/pr-ready-review.yml
@@ -46,12 +46,28 @@ jobs:
       pull-requests: read
       id-token: write
     steps:
+      # Mirrors the codex/pi guards: with no credential the action runs and fails, which
+      # reads as a broken build rather than an unconfigured optional reviewer.
+      - name: Check Claude configuration
+        id: claude_config
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "CLAUDE_CODE_OAUTH_TOKEN is not configured; skipping Claude review."
+          fi
+
       - name: Checkout repository
+        if: steps.claude_config.outputs.enabled == 'true'
         uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
       - name: Resolve PR number
+        if: steps.claude_config.outputs.enabled == 'true'
         id: resolve
         env:
           INPUT_PR_NUMBER: ${{ inputs.pr_number }}
@@ -64,6 +80,7 @@ jobs:
           fi
 
       - name: Fetch prior PR discussion
+        if: steps.claude_config.outputs.enabled == 'true'
         id: prior
         env:
           GH_TOKEN: ${{ github.token }}
@@ -82,6 +99,7 @@ jobs:
           ' prior-comments.json > prior-comments.md
 
       - name: Read review prompt
+        if: steps.claude_config.outputs.enabled == 'true'
         id: review-prompt
         env:
           EXTRA_PROMPT: ${{ inputs.extra_prompt }}
@@ -105,6 +123,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Automatic PR Review
+        if: steps.claude_config.outputs.enabled == 'true'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/pr-review-commands.yml
+++ b/.github/workflows/pr-review-commands.yml
@@ -42,11 +42,24 @@ jobs:
               ;;
           esac
 
-  acknowledge:
+  # author_association misses private org members; check-access resolves them via the
+  # internal app token. Both are OR'd so public members still pass instantly.
+  check-access:
     needs: [parse]
+    if: needs.parse.outputs.command != ''
+    uses: ./.github/workflows/check-write-access.yml
+    with:
+      username: ${{ github.event.comment.user.login }}
+    secrets: inherit
+
+  acknowledge:
+    needs: [parse, check-access]
     if: |
       needs.parse.outputs.command != '' &&
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+      (
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) ||
+        needs.check-access.outputs.authorized == 'true'
+      )
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -62,11 +75,153 @@ jobs:
             "/repos/$REPO/issues/comments/$COMMENT_ID/reactions" \
             -f content=eyes >/dev/null
 
-  claude:
-    needs: [parse]
+  # Decide, per agent, whether to launch a fresh run, re-run in place, or skip. A push
+  # already auto-triggers codex/pi (and claude on open) against the PR head. Relaunching
+  # via this issue_comment path both cancels those in-flight auto runs (shared concurrency
+  # group) AND lands the new run's status on main — issue_comment runs never attach a
+  # check to the PR head — leaving the PR showing only a cancelled review. So for every
+  # command, launch an agent only when nothing covers the head commit; if the head's run
+  # was cancelled/failed, re-run it in place (a re-run keeps the original pull_request
+  # event, so its checks re-attach to the PR head); skip when a running or successful run
+  # already covers it. `/review` applies this to all three agents; `/codex`, `/pi`,
+  # `/claude` apply the same decision to just their own agent.
+  plan:
+    needs: [parse, check-access]
     if: |
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
-      (needs.parse.outputs.command == 'review' || needs.parse.outputs.command == 'claude')
+      needs.parse.outputs.command != '' &&
+      (
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) ||
+        needs.check-access.outputs.authorized == 'true'
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+      pull-requests: read
+      statuses: write
+    outputs:
+      head_sha: ${{ steps.plan.outputs.head_sha }}
+      launch_codex: ${{ steps.plan.outputs.launch_codex }}
+      launch_pi: ${{ steps.plan.outputs.launch_pi }}
+      launch_claude: ${{ steps.plan.outputs.launch_claude }}
+    steps:
+      - name: Decide per-agent launch vs re-run for the head commit
+        id: plan
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          COMMAND: ${{ needs.parse.outputs.command }}
+        run: |
+          set -euo pipefail
+
+          HEAD_SHA=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid --jq '.headRefOid')
+          echo "PR #$PR_NUMBER head: $HEAD_SHA"
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+
+          RUN_URL="$GITHUB_SERVER_URL/$REPO/actions/runs/$GITHUB_RUN_ID"
+
+          # A fresh launch runs from this issue_comment workflow (associated with main),
+          # so it never appears in the PR-head run query below and its own check lands on
+          # main, not the head. To keep fresh launches idempotent per head, mark the head
+          # SHA with a `review-launch/<agent>` commit status at launch; the `finalize` job
+          # resolves it to success/failure. A prior launch's status covering the head lets
+          # a second comment skip instead of relaunching (which would cancel the first via
+          # the reviewer's shared concurrency group). All status calls are best-effort — a
+          # GitHub API hiccup must degrade to a relaunch, never abort the decision.
+          mark_launch() {
+            agent="$1"
+            gh api -X POST "repos/$REPO/statuses/$HEAD_SHA" \
+              -f state=pending -f "context=review-launch/$agent" -f "target_url=$RUN_URL" \
+              -f "description=Review launched via /$COMMAND" >/dev/null 2>&1 || true
+          }
+
+          # Returns "covered" if a prior fresh launch (this or an earlier comment run)
+          # already covers the head: a success status, or a pending status whose launching
+          # run is still alive. A pending whose run has completed is stale (that run
+          # crashed before finalize) and does not count.
+          launch_coverage() {
+            agent="$1"
+            st_json=$(gh api "repos/$REPO/commits/$HEAD_SHA/statuses" \
+              --jq "[.[] | select(.context == \"review-launch/$agent\")] | first // empty" 2>/dev/null || true)
+            [ -n "$st_json" ] || return 0
+            state=$(jq -r '.state // empty' <<<"$st_json" 2>/dev/null || true)
+            [ "$state" = success ] && { echo covered; return 0; }
+            [ "$state" = pending ] || return 0
+            target=$(jq -r '.target_url // empty' <<<"$st_json" 2>/dev/null || true)
+            run_id=$(printf '%s' "$target" | grep -oE '[0-9]+$' || true)
+            if [ -n "$run_id" ]; then
+              run_state=$(gh run view "$run_id" --repo "$REPO" --json status --jq '.status' 2>/dev/null || true)
+              [ "$run_state" = completed ] && return 0   # stale pending -> not covered
+            fi
+            echo covered
+          }
+
+          decide() {
+            wf="$1"; key="$2"; agent="$3"
+            if [ "$(launch_coverage "$agent")" = covered ]; then
+              echo "$key: a prior launch already covers $HEAD_SHA (review-launch/$agent) -> skip"
+              echo "$key=false" >> "$GITHUB_OUTPUT"
+              return
+            fi
+            # `--commit` matches runs whose head SHA is the PR head. Auto reviews run on
+            # `pull_request` against that SHA; `/review` (issue_comment) runs execute on
+            # main, so they never match and are not counted as covering the head commit.
+            runs=$(gh run list --repo "$REPO" --workflow "$wf" --commit "$HEAD_SHA" --limit 40 \
+              --json databaseId,status,conclusion)
+            # Healthy = still running, or completed successfully: a review already
+            # covers this commit, so skip.
+            healthy=$(jq -r '[.[] | select(.status != "completed" or .conclusion == "success")] | length' <<<"$runs")
+            if [ "$healthy" -gt 0 ]; then
+              echo "$key: a running or successful review already covers $HEAD_SHA -> skip"
+              echo "$key=false" >> "$GITHUB_OUTPUT"
+              return
+            fi
+            # Re-run only genuinely interrupted runs (cancelled/failed/timed out) in
+            # place, so their checks re-attach to the PR head instead of posting on
+            # main. A `skipped` run produced no review and would just skip again (it is
+            # the draft/fork gate), so it does not count — fall through to a fresh launch.
+            retry_id=$(jq -r '[.[] | select(.status == "completed" and (.conclusion == "cancelled" or .conclusion == "failure" or .conclusion == "timed_out"))] | sort_by(.databaseId) | last | .databaseId // empty' <<<"$runs")
+            if [ -n "$retry_id" ]; then
+              if gh run rerun "$retry_id" --repo "$REPO" >/dev/null 2>&1; then
+                echo "$key: re-ran interrupted run $retry_id (re-attaches to PR head)"
+                echo "$key=false" >> "$GITHUB_OUTPUT"
+                return
+              fi
+              echo "$key: re-run of $retry_id failed -> fresh launch"
+              mark_launch "$agent"
+              echo "$key=true" >> "$GITHUB_OUTPUT"
+              return
+            fi
+            echo "$key: no usable review for $HEAD_SHA -> launch"
+            mark_launch "$agent"
+            echo "$key=true" >> "$GITHUB_OUTPUT"
+          }
+
+          # `/review` targets all three agents; `/codex`, `/pi`, `/claude` target only
+          # their own. A non-targeted agent is left untouched (no launch, no re-run).
+          decide_if_targeted() {
+            wf="$1"; key="$2"; agent="$3"
+            if [ "$COMMAND" = review ] || [ "$COMMAND" = "$agent" ]; then
+              decide "$wf" "$key" "$agent"
+            else
+              echo "$key: /$COMMAND does not target $agent -> skip"
+              echo "$key=false" >> "$GITHUB_OUTPUT"
+            fi
+          }
+
+          decide_if_targeted codex-pr-review.yml launch_codex codex
+          decide_if_targeted pi-pr-review.yml launch_pi pi
+          decide_if_targeted pr-ready-review.yml launch_claude claude
+
+  claude:
+    needs: [parse, check-access, plan]
+    if: |
+      (
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) ||
+        needs.check-access.outputs.authorized == 'true'
+      ) &&
+      needs.plan.outputs.launch_claude == 'true'
     permissions:
       contents: read
       pull-requests: read
@@ -80,10 +235,13 @@ jobs:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
   codex:
-    needs: [parse]
+    needs: [parse, check-access, plan]
     if: |
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
-      (needs.parse.outputs.command == 'review' || needs.parse.outputs.command == 'codex')
+      (
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) ||
+        needs.check-access.outputs.authorized == 'true'
+      ) &&
+      needs.plan.outputs.launch_codex == 'true'
     permissions:
       contents: read
       issues: write
@@ -97,10 +255,13 @@ jobs:
       CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
 
   pi:
-    needs: [parse]
+    needs: [parse, check-access, plan]
     if: |
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
-      (needs.parse.outputs.command == 'review' || needs.parse.outputs.command == 'pi')
+      (
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) ||
+        needs.check-access.outputs.authorized == 'true'
+      ) &&
+      needs.plan.outputs.launch_pi == 'true'
     permissions:
       contents: read
       issues: write
@@ -112,3 +273,34 @@ jobs:
       triggered_by: ${{ github.event.comment.user.login }}
     secrets:
       DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+
+  # Resolve the `review-launch/<agent>` head statuses that `plan` set to pending, so a
+  # fresh launch's outcome is visible on the PR head (not just on main) and never lingers
+  # as a stale pending check. Targets the exact SHA `plan` launched against, so a push
+  # that moved the head mid-review does not stamp a status on the new head.
+  finalize:
+    needs: [plan, claude, codex, pi]
+    if: always() && needs.plan.result == 'success' && needs.plan.outputs.head_sha != ''
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      HEAD_SHA: ${{ needs.plan.outputs.head_sha }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Finalize launch statuses on the PR head
+        run: |
+          set -uo pipefail
+          finalize() {
+            agent="$1"; launched="$2"; result="$3"
+            [ "$launched" = true ] || return 0
+            state=$([ "$result" = success ] && echo success || echo failure)
+            gh api -X POST "repos/$REPO/statuses/$HEAD_SHA" \
+              -f "state=$state" -f "context=review-launch/$agent" -f "target_url=$RUN_URL" \
+              -f "description=Review $result" >/dev/null 2>&1 || true
+          }
+          finalize codex "${{ needs.plan.outputs.launch_codex }}" "${{ needs.codex.result }}"
+          finalize pi "${{ needs.plan.outputs.launch_pi }}" "${{ needs.pi.result }}"
+          finalize claude "${{ needs.plan.outputs.launch_claude }}" "${{ needs.claude.result }}"


### PR DESCRIPTION
## Summary

The three AI reviewers have **never executed once** in this repository. Every run of
`Codex Auto Review`, `Pi Auto Review` and `Claude Auto Review` — the last 25 of each —
concluded `skipped`, on both the automatic and the `/review` path.

**Automatic path.** The reviewer jobs gate on
`github.event.pull_request.author_association`. The `pull_request` webhook payload reports
**private** org members as `CONTRIBUTOR`/`NONE` (only *public* members show as `MEMBER`),
and the release bot the same way, so the gate rejects nearly every PR this repo sees.
windmill-labs/windmill#9958 fixed exactly this by dropping `author_association` in favour
of `head.repo.fork == false` — equivalent, since a non-fork PR can only be opened by
someone with push access, and independent of membership visibility. That fix never reached
this repo.

**Command path.** `/review` had neither the `check-write-access` step (which resolves
private members via the internal app token) nor the per-agent launch planning that windmill
grew alongside #9958.

This ports both. The reviewer workflows end up byte-identical to windmill's apart from
`runs-on` and this repo's narrower secret set.

## Changes

- `codex-pr-review.yml`, `pi-pr-review.yml`, `pr-ready-review.yml`: drop the
  `author_association` clause, keep `head.repo.fork == false`. Carries over windmill's
  comment explaining why it must not be re-added.
- `check-write-access.yml`: new, ported from windmill.
- `pr-review-commands.yml`: ported from windmill — adds the `check-access`, `plan` and
  `finalize` jobs, and ORs `author_association` with `check-access` in every gate. `plan`
  makes `/review` idempotent per head SHA: it skips agents already covered by a running or
  successful run, re-runs interrupted ones in place so their checks re-attach to the PR
  head, and only launches fresh when nothing covers the head.
- `pr-ready-review.yml`: guard every step on a `CLAUDE_CODE_OAUTH_TOKEN` presence check,
  mirroring the guards codex and pi already have (see below).

### Two deliberate divergences from windmill

**1. `check-write-access` token minting is non-fatal here.** It is *additive* by design —
callers OR it with `author_association` — so it must never fail. Guarded with
`if: vars.INTERNAL_APP_ID != ''` plus `continue-on-error`, falling back to `github.token`.
Without that, an unconfigured app would fail `check-access`, skipping `plan`, skipping all
three reviewers through `needs` — turning a missing variable into a *total* review outage
instead of a graceful fallback. windmill does not hit this because the app is configured
there. Worth porting back.

**2. Claude gets a credential guard.** Codex and pi already check their secret and skip
with a message; Claude did not, so with no token the action ran and **failed**, making an
unconfigured optional reviewer look like a broken build. Confirmed live on this PR: the
first push produced a red `Claude Auto Review`; with the guard it is green with every step
skipped.

## Confirmed: this repo cannot reach any reviewer credential

This PR was opened ready rather than draft specifically to test the automatic path
(`pull_request` workflows run from the PR's merge ref, whereas `issue_comment` workflows
always run from the default branch, so `/review` cannot be tested before merge).

The gate fix works — all three jobs now **run** instead of skipping. What they print:

```
CODEX_AUTH_JSON is not configured; skipping Codex review.
DEEPSEEK_API_KEY is not configured; skipping Pi review.
CLAUDE_CODE_OAUTH_TOKEN is not configured; skipping Claude review.
```

So the gate was necessary but not sufficient. `gh secret list --repo windmill-labs/windmill-helm-charts`
returns empty, and these are org secrets whose visibility does not include this repository.
**Making the reviewers actually review requires an org admin to share `CODEX_AUTH_JSON`,
`CLAUDE_CODE_OAUTH_TOKEN` and `DEEPSEEK_API_KEY` (plus `INTERNAL_APP_ID` / `INTERNAL_APP_KEY`
for private-member resolution) with `windmill-labs/windmill-helm-charts`.** This PR cannot
do that, but it is the prerequisite: with the gates fixed, sharing the secrets is all that
is left.

## Test plan

- [x] All eight workflow files parse as YAML.
- [x] Every `needs:` target resolves; every local `uses:` path exists.
- [x] Caller/callee contracts match exactly for all three reviewers (`pr_number`,
      `extra_prompt`, `triggered_by`; `CODEX_AUTH_JSON` / `DEEPSEEK_API_KEY` /
      `CLAUDE_CODE_OAUTH_TOKEN`), so no undeclared secret or input is passed.
- [x] The codex gate is byte-identical to windmill's working one apart from `runs-on`.
- [x] This PR's own `Codex`/`Pi`/`Claude Auto Review` jobs execute instead of skipping.
- [x] All three degrade cleanly (green, steps skipped) when the credential is absent.
- [ ] Org admin shares the reviewer secrets with this repo, then reviews actually appear.
- [ ] After merge: `/review` on a draft PR produces reviews.