### PR TITLE
fix(ci): authenticate Codex with OPENAI_API_KEY when available

### DIFF
--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -20,6 +20,8 @@ on:
         type: string
         default: ''
     secrets:
+      OPENAI_API_KEY:
+        required: false
       CODEX_AUTH_JSON:
         required: false
 
@@ -50,13 +52,18 @@ jobs:
       - name: Check Codex configuration
         id: codex_config
         env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
         run: |
-          if [ -n "$CODEX_AUTH_JSON" ]; then
+          if [ -n "$OPENAI_API_KEY" ]; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "auth_mode=api_key" >> "$GITHUB_OUTPUT"
+          elif [ -n "$CODEX_AUTH_JSON" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "auth_mode=oauth_json" >> "$GITHUB_OUTPUT"
           else
             echo "enabled=false" >> "$GITHUB_OUTPUT"
-            echo "CODEX_AUTH_JSON is not configured; skipping Codex review."
+            echo "Codex auth is not configured; set OPENAI_API_KEY or CODEX_AUTH_JSON to enable Codex review."
           fi
 
       - name: Resolve PR metadata
@@ -131,6 +138,7 @@ jobs:
       - name: Configure file-backed Codex auth
         if: steps.codex_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
         env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
         run: |
           CODEX_HOME="$HOME/.codex"
@@ -140,9 +148,16 @@ jobs:
           cat > "$CODEX_HOME/config.toml" <<'EOF'
           cli_auth_credentials_store = "file"
           EOF
-          printf '%s' "$CODEX_AUTH_JSON" > "$CODEX_HOME/auth.json"
-          chmod 600 "$CODEX_HOME/auth.json"
-          node -e 'JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"))' "$CODEX_HOME/auth.json"
+          # CODEX_AUTH_JSON holds a ChatGPT OAuth blob whose refresh token is single-use:
+          # once any run rotates it, every stored copy is dead and Codex 401s. Prefer the
+          # API key, which does not rotate.
+          if [ -n "$OPENAI_API_KEY" ]; then
+            printf '%s' "$OPENAI_API_KEY" | codex login --with-api-key
+          else
+            printf '%s' "$CODEX_AUTH_JSON" > "$CODEX_HOME/auth.json"
+            chmod 600 "$CODEX_HOME/auth.json"
+            node -e 'JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"))' "$CODEX_HOME/auth.json"
+          fi
 
       - name: Pre-fetch base and head refs for the PR
         if: steps.codex_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'

--- a/.github/workflows/pr-review-commands.yml
+++ b/.github/workflows/pr-review-commands.yml
@@ -252,6 +252,7 @@ jobs:
       extra_prompt: ${{ needs.parse.outputs.extra_prompt }}
       triggered_by: ${{ github.event.comment.user.login }}
     secrets:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
 
   pi:


### PR DESCRIPTION
## Summary

Follow-up to #656. With `CODEX_AUTH_JSON` now shared with this repo, Codex gets past the
credential guard and then fails:

```
ERROR codex_login::auth::manager: Failed to refresh token: Your access token could not be
refreshed because your refresh token was already used. Please log out and sign in again.
ERROR codex_api::endpoint::responses_websocket: failed to connect to websocket:
HTTP error: 401 Unauthorized, url: wss://chatgpt.com/backend-api/codex/responses
```

`CODEX_AUTH_JSON` is a ChatGPT OAuth blob whose **refresh token is single-use**: the first
run to refresh it rotates the token, and every stored copy of the blob is dead from that
point on. It is therefore not a credential that can be handed to a second repository and
expected to keep working.

windmill already prefers `OPENAI_API_KEY` for exactly this reason and keeps
`CODEX_AUTH_JSON` only as a fallback (`OPENAI_API_KEY` is a repo secret there, so its Codex
runs never touch the OAuth path). This repository carried the older copy of the workflow
that supports **only** the OAuth blob, so it 401s the moment the blob is wired up.

## Changes

- `codex-pr-review.yml`: declare `OPENAI_API_KEY` as an optional `workflow_call` secret;
  select `auth_mode=api_key` when it is set, falling back to `oauth_json`; authenticate via
  `codex login --with-api-key` in that mode instead of writing `auth.json`. Brings the
  config check and auth steps to parity with windmill.
- `pr-review-commands.yml`: pass `OPENAI_API_KEY` through to the codex job.

## Required alongside this PR

`OPENAI_API_KEY` must be visible to `windmill-labs/windmill-helm-charts` (repo id
`542651544`). It is a **repo** secret in `windmill-labs/windmill`, so it likely needs
creating at org level with this repo selected, or adding directly as a repo secret here.

Without it this PR is a no-op: the workflow falls back to `CODEX_AUTH_JSON` and 401s the
same way. With it, Codex authenticates with a non-rotating credential and stops depending
on the shared blob entirely.

Pi and Claude remain unconfigured (`DEEPSEEK_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`); both skip
cleanly and are unaffected by this change.

## Test plan

- [x] Both workflow files parse; callee-declared secrets and caller-passed secrets match
      exactly (`CODEX_AUTH_JSON`, `OPENAI_API_KEY`).
- [x] Failure reproduced on #655 head `eed06b4` (run 30903440581) with the OAuth-only path.
- [ ] With `OPENAI_API_KEY` shared: Codex Auto Review runs green and posts a review.