### PR TITLE
Bump chart version to 4.0.233

### DIFF
--- a/charts/windmill/Chart.yaml
+++ b/charts/windmill/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: windmill
 type: application
-version: 4.0.232
+version: 4.0.233
 appVersion: 1.782.0
 dependencies:
   - condition: minio.enabled


### PR DESCRIPTION
Re-release of appVersion `1.782.0` — chart version only, no chart content change.

The `4.0.232` gh-pages deployment was cancelled twice after `actions/deploy-pages` hit its 10 minute timeout, during the ongoing GitHub Pages deployment-lag incident (https://stspg.io/b0n00sx9z3ht):

- attempt 1 (13:05Z): stuck at `deployment_queued` for the full timeout
- attempt 2 (14:54Z): stuck at `deployment_in_progress` for the full timeout

The `index.yaml` commit for 4.0.232 is on `gh-pages`, but the public repo still serves 4.0.231, so `helm repo update` does not resolve 1.782.0. GHCR/OCI and the release `.tgz` are unaffected.

Bumping the chart version triggers a fresh chart-releaser run and a new Pages deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)