### PR TITLE
fix(helm): give the indexer rollout room for the index write-lock handoff

### DIFF
--- a/charts/windmill/Chart.yaml
+++ b/charts/windmill/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: windmill
 type: application
-version: 4.0.238
+version: 4.0.239
 appVersion: 1.789.0
 dependencies:
   - condition: minio.enabled

--- a/charts/windmill/README.md
+++ b/charts/windmill/README.md
@@ -198,6 +198,7 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.indexer.podSecurityContext | object | `{"runAsNonRoot":false,"runAsUser":0}` | Security context to apply to the pods |
 | windmill.indexer.podSecurityContext.runAsNonRoot | bool | `false` | run explicitly as a non-root user. The default is false. |
 | windmill.indexer.podSecurityContext.runAsUser | int | `0` | run as user. The default is 0 for root user |
+| windmill.indexer.progressDeadlineSeconds | int | `1800` | How long a rollout may take before Kubernetes reports ProgressDeadlineExceeded. The incoming pod waits for the outgoing one to hand over the index write lock and then loads the index from object storage, so raise this further if your index is large enough that upgrades still time out. |
 | windmill.indexer.resources | object | `{"limits":{"ephemeral-storage":"50Gi","memory":"2Gi"}}` | Resource limits and requests for the pods |
 | windmill.indexer.securityContext | string | `nil` | legacy, use podSecurityContext instead |
 | windmill.indexer.tolerations | list | `[]` | Tolerations to apply to the pods |

--- a/charts/windmill/templates/indexer.yaml
+++ b/charts/windmill/templates/indexer.yaml
@@ -15,11 +15,19 @@ spec:
   replicas: 1
   {{- end }}
   revisionHistoryLimit: 3
+  # A surged pod is required, not incidental: the incoming pod is what signals the
+  # outgoing one to hand over the index write lock, and the outgoing one keeps serving
+  # searches read-only until the new pod is ready. Recreate breaks both halves and
+  # takes search down for the whole restart, including the index load from object storage.
   strategy:
     type: RollingUpdate
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 0
+  # The handoff also has to wait out the outgoing pod's in-flight index refresh and
+  # merge flush, which can exceed the 600s default and get a healthy rollout reported
+  # as ProgressDeadlineExceeded.
+  progressDeadlineSeconds: {{ .Values.windmill.indexer.progressDeadlineSeconds | default 1800 }}
   selector:
     matchLabels:
       app: windmill-indexer

--- a/charts/windmill/values.yaml
+++ b/charts/windmill/values.yaml
@@ -547,6 +547,12 @@ windmill:
     # -- enable or disable indexer
     enabled: true
 
+    # -- How long a rollout may take before Kubernetes reports ProgressDeadlineExceeded.
+    # The incoming pod waits for the outgoing one to hand over the index write lock and
+    # then loads the index from object storage, so raise this further if your index is
+    # large enough that upgrades still time out.
+    progressDeadlineSeconds: 1800
+
     # -- Annotations to apply to the pods
     annotations: {}
 


### PR DESCRIPTION
Fixes WIN-2380

## Why not Recreate

WIN-2380 proposed switching `windmill-indexer` from `RollingUpdate` to `Recreate`, on the reasoning that a surged pod can never pass readiness while the old pod holds the index write lock. The surge is load-bearing, though, and removing it trades a reporting problem for a real outage.

Only one indexer may hold the index write lock, but the code has a handoff for exactly this: `acquire_primary_lock` has the **incoming** pod take the handoff lock, which is the signal the outgoing pod polls (`should_handoff`) to release the primary lock. The outgoing pod then stops writing but **keeps answering searches**, flagging `lost_lock_ownership` in the result metadata so the UI can say the index is stale. `maxSurge: 1` is what creates the pod that sends the signal, and `maxUnavailable: 0` is what keeps the old one serving until the new one is ready. Search stays up across an upgrade because of the overlap, not in spite of it.

## What actually goes wrong

The clock, not the lock. The handoff has to wait out the outgoing pod's in-flight index refresh and its merge flush, then the incoming pod loads the index from object storage. That can exceed the 600s `progressDeadlineSeconds` default, at which point Kubernetes marks a perfectly healthy rollout `ProgressDeadlineExceeded` — which `helm upgrade --wait`, `kubectl rollout status`, Argo CD and Flux all surface as a failed deploy. Deleting pods to unstick it is what puts two ReplicaSets in contention over the locks, which is the restart loop described in the issue.

## Change

- Keep `RollingUpdate` with `maxSurge: 1` / `maxUnavailable: 0`, and record in the template why the surge exists, so it does not get "simplified" to `Recreate` later.
- Set `progressDeadlineSeconds`, default `1800`, configurable via `windmill.indexer.progressDeadlineSeconds` for instances whose index load is slower still.

No pod-level change, so running indexers are unaffected on upgrade.

## Validation

`helm lint` and `helm template` clean against both `ci/ee-values.yaml` and `ci/oss-values.yaml`; rendered manifest accepted by `kubectl apply --dry-run=server`. Chart version bumped, which `ct lint` requires.

Behaviour was measured on a kind cluster against an emulation of the handoff (flock-based writer lock, survivor that releases the lock but keeps serving HTTP, 20s simulated index load), sampling ready Service endpoints once a second across a rollout:

| strategy | rollout | samples with zero ready endpoints |
|---|---|---|
| `RollingUpdate` (kept) | succeeded | **0 / 70** |
| `Recreate` (proposed) | succeeded | **25 / 70** |

The `Recreate` gap spans the whole restart including the index load, so it grows with index size — 25s here is a floor, not an estimate.

For the deadline, with the handoff stretched to 70s:

| `progressDeadlineSeconds` | `kubectl rollout status` |
|---|---|
| 30 (stands in for the 600s default) | `error: deployment "indexer" exceeded its progress deadline` — then converged on its own, untouched |
| 1800 (this PR) | success, exit 0, `Progressing=True reason=NewReplicaSetAvailable`, 0 / 170 zero-endpoint samples |

## Follow-up, not in this PR

`should_handoff` is only polled while the indexer is idle between refreshes, so a long in-flight `refresh_jobs` delays the handoff by its full duration. Raising the deadline absorbs that; making the refresh loop cancellable on the handoff signal would shorten it. That is a backend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)