### PR TITLE
feat: consume the database url from a file and add liveness probes

### DIFF
--- a/charts/windmill/Chart.yaml
+++ b/charts/windmill/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: windmill
 type: application
-version: 4.0.229
+version: 4.0.230
 appVersion: 1.781.0
 dependencies:
   - condition: minio.enabled

--- a/charts/windmill/README.md
+++ b/charts/windmill/README.md
@@ -80,12 +80,10 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | hub.initContainers | list | `[]` | Extra init containers |
 | hub.labels | object | `{}` | Annotations to apply to the pods |
 | hub.licenseKey | string | `""` | enterprise license key, deprecated use the enterprise values instead |
-| hub.livenessProbe | object | `{"failureThreshold":6,"initialDelaySeconds":30,"periodSeconds":10,"tcpSocket":{"port":3000},"timeoutSeconds":5}` | Liveness probe for the hub pods. Set to {} to remove it. Deliberately a socket check rather than /ready: a slow embeddings load is not a reason to restart the pod. |
 | hub.nodeSelector | object | `{}` | Node selector to use for scheduling the pods |
 | hub.podSecurityContext | object | `{"runAsNonRoot":false,"runAsUser":0}` | Security context to apply to the pods |
 | hub.podSecurityContext.runAsNonRoot | bool | `false` | run explicitly as a non-root user. The default is false. |
 | hub.podSecurityContext.runAsUser | int | `0` | run as user. The default is 0 for root user |
-| hub.readinessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/ready","port":3000,"scheme":"HTTP"},"initialDelaySeconds":10,"periodSeconds":10,"timeoutSeconds":5}` | Readiness probe for the hub pods. Set to {} to remove it. /ready reports 503 until the embeddings database has finished loading, which can take a while on a cold start. |
 | hub.replicas | int | `1` | replicas for the hub |
 | hub.resources | object | `{"limits":{"memory":"2Gi"}}` | Resource limits and requests for the pods |
 | hub.securityContext | string | `nil` | legacy, use podSecurityContext instead |
@@ -135,7 +133,6 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.app.hostAliases | list | `[]` | Host aliases to apply to the pods (overrides global hostAliases if set) |
 | windmill.app.initContainers | list | `[]` | Init containers |
 | windmill.app.labels | object | `{}` | Annotations to apply to the pods |
-| windmill.app.livenessProbe | object | `{"failureThreshold":6,"httpGet":{"path":"/api/version","port":8000,"scheme":"HTTP"},"initialDelaySeconds":30,"periodSeconds":10,"timeoutSeconds":5}` | Liveness probe for the app pods. Set to {} to remove it. /api/version is a static handler that touches no dependency, so only a wedged process fails it: a probe that depended on the database would restart every pod at once during a database outage. |
 | windmill.app.nodeSelector | object | `{}` | Node selector to use for scheduling the pods |
 | windmill.app.podSecurityContext | object | `{"runAsNonRoot":false,"runAsUser":0}` | Security context to apply to the pods |
 | windmill.app.podSecurityContext.runAsNonRoot | bool | `false` | run explicitly as a non-root user. The default is false. |
@@ -165,7 +162,6 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.app.smtpTls.certSecretName | string | `""` | name of the Kubernetes Secret containing the certificate and key |
 | windmill.app.smtpTls.enabled | bool | `false` | enable mounting a TLS certificate for the SMTP server |
 | windmill.app.smtpTls.keySecretKey | string | `"tls.key"` | key in the Secret for the private key PEM file (must be PKCS#8 format) |
-| windmill.app.startupProbe | object | `{"failureThreshold":60,"httpGet":{"path":"/api/version","port":8000,"scheme":"HTTP"},"periodSeconds":10,"timeoutSeconds":5}` | Startup probe for the app pods. Set to {} to remove it. It keeps the liveness probe disabled until the process serves HTTP, which it does not do while a long migration runs on upgrade. Without it a slow migration would restart every pod before it ever came up. |
 | windmill.app.tolerations | list | `[]` | Tolerations to apply to the pods |
 | windmill.app.topologySpreadConstraints | list | `[]` | Topology spread constraints |
 | windmill.app.volumeMounts | list | `[]` |  |
@@ -200,7 +196,6 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.indexer.extraEnv | list | `[]` | Extra environment variables to apply to the pods |
 | windmill.indexer.initContainers | list | `[]` | Extra init containers |
 | windmill.indexer.labels | object | `{}` | Annotations to apply to the pods |
-| windmill.indexer.livenessProbe | object | `{"failureThreshold":6,"httpGet":{"path":"/api/version","port":8000,"scheme":"HTTP"},"initialDelaySeconds":30,"periodSeconds":10,"timeoutSeconds":5}` | Liveness probe for the indexer pods. Set to {} to remove it. See windmill.app.livenessProbe for why this deliberately does not check the database. |
 | windmill.indexer.nodeSelector | object | `{}` | Node selector to use for scheduling the pods |
 | windmill.indexer.podSecurityContext | object | `{"runAsNonRoot":false,"runAsUser":0}` | Security context to apply to the pods |
 | windmill.indexer.podSecurityContext.runAsNonRoot | bool | `false` | run explicitly as a non-root user. The default is false. |
@@ -208,7 +203,6 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.indexer.progressDeadlineSeconds | int | `1800` | How long a rollout may take before Kubernetes reports ProgressDeadlineExceeded. The incoming pod waits for the outgoing one to hand over the index write lock and then loads the index from object storage, so raise this further if your index is large enough that upgrades still time out. |
 | windmill.indexer.resources | object | `{"limits":{"ephemeral-storage":"50Gi","memory":"2Gi"}}` | Resource limits and requests for the pods |
 | windmill.indexer.securityContext | string | `nil` | legacy, use podSecurityContext instead |
-| windmill.indexer.startupProbe | object | `{"failureThreshold":180,"httpGet":{"path":"/api/version","port":8000,"scheme":"HTTP"},"periodSeconds":10,"timeoutSeconds":5}` | Startup probe for the indexer pods. Set to {} to remove it. The indexer loads its index from object storage before it starts serving HTTP, so the liveness probe must stay disabled until that finishes or a large index restarts the pod forever. Keep the budget (periodSeconds x failureThreshold) at least as large as progressDeadlineSeconds. |
 | windmill.indexer.tolerations | list | `[]` | Tolerations to apply to the pods |
 | windmill.indexer.volumeMounts | list | `[]` | Extra volume mounts to add to the container |
 | windmill.indexer.volumes | list | `[]` | Extra volumes to add to the pods |

--- a/charts/windmill/README.md
+++ b/charts/windmill/README.md
@@ -1,6 +1,6 @@
 # windmill
 
-![Version: 4.0.174](https://img.shields.io/badge/Version-4.0.174-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.721.0](https://img.shields.io/badge/AppVersion-1.721.0-informational?style=flat-square)
+![Version: 4.0.230](https://img.shields.io/badge/Version-4.0.230-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.781.0](https://img.shields.io/badge/AppVersion-1.781.0-informational?style=flat-square)
 
 Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 
@@ -80,10 +80,12 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | hub.initContainers | list | `[]` | Extra init containers |
 | hub.labels | object | `{}` | Annotations to apply to the pods |
 | hub.licenseKey | string | `""` | enterprise license key, deprecated use the enterprise values instead |
+| hub.livenessProbe | object | `{"failureThreshold":6,"initialDelaySeconds":30,"periodSeconds":10,"tcpSocket":{"port":3000},"timeoutSeconds":5}` | Liveness probe for the hub pods. Set to {} to remove it. Deliberately a socket check rather than /ready: a slow embeddings load is not a reason to restart the pod. |
 | hub.nodeSelector | object | `{}` | Node selector to use for scheduling the pods |
 | hub.podSecurityContext | object | `{"runAsNonRoot":false,"runAsUser":0}` | Security context to apply to the pods |
 | hub.podSecurityContext.runAsNonRoot | bool | `false` | run explicitly as a non-root user. The default is false. |
 | hub.podSecurityContext.runAsUser | int | `0` | run as user. The default is 0 for root user |
+| hub.readinessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/ready","port":3000,"scheme":"HTTP"},"initialDelaySeconds":10,"periodSeconds":10,"timeoutSeconds":5}` | Readiness probe for the hub pods. Set to {} to remove it. /ready reports 503 until the embeddings database has finished loading, which can take a while on a cold start. |
 | hub.replicas | int | `1` | replicas for the hub |
 | hub.resources | object | `{"limits":{"memory":"2Gi"}}` | Resource limits and requests for the pods |
 | hub.securityContext | string | `nil` | legacy, use podSecurityContext instead |
@@ -133,10 +135,12 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.app.hostAliases | list | `[]` | Host aliases to apply to the pods (overrides global hostAliases if set) |
 | windmill.app.initContainers | list | `[]` | Init containers |
 | windmill.app.labels | object | `{}` | Annotations to apply to the pods |
+| windmill.app.livenessProbe | object | `{"failureThreshold":6,"httpGet":{"path":"/api/version","port":8000,"scheme":"HTTP"},"initialDelaySeconds":30,"periodSeconds":10,"timeoutSeconds":5}` | Liveness probe for the app pods. Set to {} to remove it. /api/version is a static handler that touches no dependency, so only a wedged process fails it: a probe that depended on the database would restart every pod at once during a database outage. |
 | windmill.app.nodeSelector | object | `{}` | Node selector to use for scheduling the pods |
 | windmill.app.podSecurityContext | object | `{"runAsNonRoot":false,"runAsUser":0}` | Security context to apply to the pods |
 | windmill.app.podSecurityContext.runAsNonRoot | bool | `false` | run explicitly as a non-root user. The default is false. |
 | windmill.app.podSecurityContext.runAsUser | int | `0` | run as user. The default is 0 for root user |
+| windmill.app.readinessProbe | object | `{"failureThreshold":1,"httpGet":{"httpHeaders":[{"name":"Host","value":"localhost"}],"path":"/","port":8000,"scheme":"HTTP"},"initialDelaySeconds":5,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":1}` | Readiness probe for the app pods. Set to {} to remove it. Point it at /api/health/status to also take a pod out of the service when its database connection is unhealthy, at the cost of removing every pod at once during a database outage. |
 | windmill.app.resources | object | `{"limits":{"memory":"2Gi"}}` | Resource limits and requests for the pods |
 | windmill.app.securityContext | object | `{}` | legacy, use podSecurityContext instead |
 | windmill.app.service.annotations | object | `{}` | Annotations to apply to the service |
@@ -172,14 +176,16 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.cookieDomain | string | `""` | domain to use for the cookies. Use it if windmill is hosted on a subdomain and you need to share the cookies with the hub for instance |
 | windmill.databaseSecret | bool | `false` | whether to create a secret containing the value of databaseUrl |
 | windmill.databaseUrl | string | `"postgres://postgres:windmill@windmill-postgresql/windmill?sslmode=disable"` | Postgres URI, pods will crashloop if database is unreachable, sets DATABASE_URL environment variable in app and worker container |
+| windmill.databaseUrlAsFile | bool | `false` | read the database URI from a file and set DATABASE_URL_FILE instead of injecting DATABASE_URL into the environment, so the connection string never appears in the pod spec. With databaseUrlSecretName or databaseSecret set, the chart mounts that secret at databaseUrlFilePath; without either, supply the file yourself with a per-component volume (an init container that decrypts it, a CSI driver, Vault Agent). Applies to the app, workers, indexer and operator; the hub reads DATABASE_URL from the environment only and is unaffected. |
+| windmill.databaseUrlFileMode | int | `292` | file mode of the mounted database URI, in octal. 0400 requires the pod to run as the owner of the projected file, so set an fsGroup matching runAsUser alongside it. |
+| windmill.databaseUrlFilePath | string | `"/etc/windmill/secrets/database-url"` | path the database URI is mounted at when databaseUrlAsFile is enabled. Its directory is the mount point, so keep it on a path of its own. |
 | windmill.databaseUrlSecretKey | string | `"url"` | name of the key in existing secret storing the database URI. The default key of the url is 'url' |
 | windmill.databaseUrlSecretName | string | `""` | name of the existing secret storing the database URI, take precedence over databaseUrl. |
 | windmill.disableUnsharePid | bool | `false` | Some systems like Bottlerocket AMI have max_user_namespaces=0 which prevents unshare from working. |
-| windmill.exposeHostDocker | bool | `false` | SECURITY RISK: mounts the host node's Docker socket into the worker, giving any user who can run a script root-equivalent control of the node's Docker daemon (and typically the cluster). Trusted, single-tenant use only — never enable for untrusted or multi-tenant workloads. Prefer a dedicated docker worker group with the rootless podman runtime (CONTAINER_RUNTIME=podman on a *-full image, run as a non-root user) instead. |
-| windmill.extraReplicas | int | `1` | replicas for the lsp smart assistant (not required but useful for the web IDE) |
 | windmill.dnsConfig | object | `{}` | DNS configuration for all Windmill pods. When dnsPolicy is "None", nameservers must include at least one resolver. Per-component dnsConfig replaces this value entirely (no deep merge) |
 | windmill.dnsPolicy | string | `""` | DNS policy for all Windmill pods (app, workers, indexer, operator, extra, hub). Valid options are "ClusterFirst", "Default", "ClusterFirstWithHostNet", "None". Can be overridden per component or per worker group |
-| windmill.exposeHostDocker | bool | `false` | mount the docker socket inside the container to be able to run docker command as docker client to the host docker daemon |
+| windmill.exposeHostDocker | bool | `false` | SECURITY RISK: mounts the host node's Docker socket into the worker, giving any user who can run a script root-equivalent control of the node's Docker daemon (and typically the cluster). Trusted, single-tenant use only — never enable for untrusted or multi-tenant workloads. Prefer a dedicated docker worker group with the rootless podman runtime (CONTAINER_RUNTIME=podman on a *-full image, run as a non-root user) instead. |
+| windmill.extraReplicas | int | `1` | replicas for windmill-extra (LSP, Multiplayer, Debugger). Set to 0 to disable. |
 | windmill.hostAliases | list | `[]` | host aliases for all pods (can be overridden by individual worker groups) |
 | windmill.image | string | `""` | windmill image tag, will use the Acorresponding ee or ce image from ghcr if not defined. Do not include tag in the image name. |
 | windmill.imagePullPolicy | string | `"Always"` | image pull policy for the app, worker, lsp and multiplayer containers |
@@ -194,13 +200,17 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.indexer.extraEnv | list | `[]` | Extra environment variables to apply to the pods |
 | windmill.indexer.initContainers | list | `[]` | Extra init containers |
 | windmill.indexer.labels | object | `{}` | Annotations to apply to the pods |
+| windmill.indexer.livenessProbe | object | `{"failureThreshold":6,"httpGet":{"path":"/api/version","port":8000,"scheme":"HTTP"},"initialDelaySeconds":30,"periodSeconds":10,"timeoutSeconds":5}` | Liveness probe for the indexer pods. Set to {} to remove it. See windmill.app.livenessProbe for why this deliberately does not check the database. |
 | windmill.indexer.nodeSelector | object | `{}` | Node selector to use for scheduling the pods |
 | windmill.indexer.podSecurityContext | object | `{"runAsNonRoot":false,"runAsUser":0}` | Security context to apply to the pods |
 | windmill.indexer.podSecurityContext.runAsNonRoot | bool | `false` | run explicitly as a non-root user. The default is false. |
 | windmill.indexer.podSecurityContext.runAsUser | int | `0` | run as user. The default is 0 for root user |
+| windmill.indexer.readinessProbe | object | `{"failureThreshold":1,"httpGet":{"httpHeaders":[{"name":"Host","value":"localhost"}],"path":"/","port":8000,"scheme":"HTTP"},"initialDelaySeconds":5,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":1}` | Readiness probe for the indexer pods. Set to {} to remove it. |
 | windmill.indexer.resources | object | `{"limits":{"ephemeral-storage":"50Gi","memory":"2Gi"}}` | Resource limits and requests for the pods |
 | windmill.indexer.securityContext | string | `nil` | legacy, use podSecurityContext instead |
 | windmill.indexer.tolerations | list | `[]` | Tolerations to apply to the pods |
+| windmill.indexer.volumeMounts | list | `[]` | Extra volume mounts to add to the container |
+| windmill.indexer.volumes | list | `[]` | Extra volumes to add to the pods |
 | windmill.instanceEventsWebhook | string | `""` | send instance events to a webhook. Can be hooked back to windmill |
 | windmill.multiplayerReplicas | int | `1` | replicas for the multiplayer containers used by the app (ee only and ignored if enterprise not enabled) |
 | windmill.npmConfigRegistry | string | `""` | pass the npm for private registries |
@@ -219,6 +229,8 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.operator.replicas | int | `1` | number of operator replicas (typically 1) |
 | windmill.operator.resources | object | `{"limits":{"memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}}` | Resource limits and requests for the pods |
 | windmill.operator.tolerations | list | `[]` | Tolerations to apply to the pods |
+| windmill.operator.volumeMounts | list | `[]` | Extra volume mounts to add to the container |
+| windmill.operator.volumes | list | `[]` | Extra volumes to add to the pods |
 | windmill.pipExtraIndexUrl | string | `""` | pass the extra index url to pip for private registries |
 | windmill.pipIndexUrl | string | `""` | pass the index url to pip for private registries |
 | windmill.pipTrustedHost | string | `""` | pass the trusted host to pip for private registries |
@@ -230,6 +242,7 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.windmillExtra.affinity | object | `{}` | Affinity rules to apply to the pods |
 | windmill.windmillExtra.annotations | object | `{}` | Annotations to apply to the pods |
 | windmill.windmillExtra.containerSecurityContext | object | `{}` | Security context to apply to the container |
+| windmill.windmillExtra.debugAllowedOrigins | string | `""` | comma-separated allowlist of browser Origins permitted to open debug WebSockets (cross-site WebSocket hijacking hardening). Empty = rely on signed-token verification only; set to your external URL(s), e.g. "https://windmill.example.com", to also reject cross-origin handshakes. |
 | windmill.windmillExtra.dnsConfig | object | `{}` | Custom DNS configuration for the pods. Falls back to windmill.dnsConfig when unset |
 | windmill.windmillExtra.dnsPolicy | string | `""` | DNS policy for the pods. Valid options are "ClusterFirst", "Default", "ClusterFirstWithHostNet", "None". Falls back to windmill.dnsPolicy when unset |
 | windmill.windmillExtra.enableDebugger | bool | `true` | enable Debugger for debugging scripts |
@@ -240,7 +253,7 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.windmillExtra.labels | object | `{}` | Labels to apply to the pods |
 | windmill.windmillExtra.nodeSelector | object | `{}` | Node selector to use for scheduling the pods |
 | windmill.windmillExtra.podSecurityContext | object | `{"runAsNonRoot":false,"runAsUser":0}` | Security context to apply to the pods |
-| windmill.windmillExtra.requireSignedDebugRequests | bool | `true` | require signed debug requests (JWT tokens for debug sessions) |
+| windmill.windmillExtra.requireSignedDebugRequests | bool | `true` | require signed debug requests (JWT tokens for debug sessions). Do NOT disable on internet-reachable deployments: it exposes an unauthenticated code-execution debugger. |
 | windmill.windmillExtra.requireSignedMultiplayerRequests | bool | `true` | require signed multiplayer requests (JWT tokens for collaborative editing sessions). Keep enabled in production. |
 | windmill.windmillExtra.resources | object | `{"limits":{"memory":"1Gi"}}` | Resource limits and requests for the pods |
 | windmill.windmillExtra.securityContext | object | `{}` | legacy, use podSecurityContext instead |
@@ -250,19 +263,25 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.windmillExtra.windmillBaseUrl | string | `""` | Set to your external URL (e.g. "https://windmill.example.com") if the debugger fails with token verification errors. |
 | windmill.workerGroups[0].affinity | object | `{}` | Affinity rules to apply to the pods |
 | windmill.workerGroups[0].annotations | object | `{}` | Annotations to apply to the pods |
+| windmill.workerGroups[0].autoscalingManaged | bool | `false` | `replicas` value above is ignored and the deployment is rendered regardless. |
+| windmill.workerGroups[0].baseUrl | string | `""` | {windmill.baseProtocol}://{windmill.baseDomain} when not set. |
 | windmill.workerGroups[0].command | list | `[]` | command override |
 | windmill.workerGroups[0].containerSecurityContext | object | `{}` | Security context to apply to the pod |
 | windmill.workerGroups[0].controller | string | `"Deployment"` | Controller to use. Valid options are "Deployment" and "StatefulSet" |
+| windmill.workerGroups[0].databaseUrlSecretKey | string | `""` | Key within databaseUrlSecretName holding the database URL. Defaults to "url" when not set. |
+| windmill.workerGroups[0].databaseUrlSecretName | string | `""` | windmill.databaseUrlSecretName. |
 | windmill.workerGroups[0].deploymentAnnotations | object | `{}` | Annotations to apply to the controller (Deployment/StatefulSet) itself |
 | windmill.workerGroups[0].disableUnsharePid | bool | `false` | Set to true for nodes where user namespaces are disabled (e.g., Bottlerocket AMI with max_user_namespaces=0). |
-| windmill.workerGroups[0].dnsConfig | object | `{}` | Custom DNS configuration for the pods. Useful for pods with VPN sidecars that need to resolve external DNS names |
-| windmill.workerGroups[0].dnsPolicy | string | `""` | DNS policy for the pods. Set to "None" when using custom dnsConfig (e.g., for VPN sidecars or custom DNS resolution) |
+| windmill.workerGroups[0].dnsConfig | object | `{}` | Useful for pods with VPN sidecars that need to resolve external DNS names. Falls back to windmill.dnsConfig when unset |
+| windmill.workerGroups[0].dnsPolicy | string | `""` | Set to "None" when using custom dnsConfig (e.g., for VPN sidecars or custom DNS resolution). Falls back to windmill.dnsPolicy when unset |
 | windmill.workerGroups[0].exposeHostDocker | bool | `false` | SECURITY RISK: mounts the host node's Docker socket into this worker group, giving any script author root-equivalent control of the node's Docker daemon. Trusted, single-tenant use only. Prefer the rootless podman runtime (CONTAINER_RUNTIME=podman on a *-full image, non-root) instead. |
 | windmill.workerGroups[0].extraContainers | list | `[]` | Extra sidecar containers |
 | windmill.workerGroups[0].extraEnv | list | `[]` | value: "/tmp" |
 | windmill.workerGroups[0].hostAliases | list | `[]` | Host aliases to apply to the pods (overrides global hostAliases if set) |
+| windmill.workerGroups[0].image | string | `""` | Falls back to windmill.image when not set. |
 | windmill.workerGroups[0].initContainers | list | `[]` | Init containers |
 | windmill.workerGroups[0].labels | object | `{}` | Labels to apply to the pods |
+| windmill.workerGroups[0].livenessProbe | object | `{}` | Liveness probe for this worker group. Empty on purpose: a restart kills the jobs the worker is running, and /ready latches to healthy once the worker has started, so it cannot detect a wedged job loop anyway. Set one only with that trade-off in mind. |
 | windmill.workerGroups[0].mode | string | `"worker"` |  |
 | windmill.workerGroups[0].name | string | `"default"` |  |
 | windmill.workerGroups[0].nodeSelector | object | `{}` | Node selector to use for scheduling the pods |
@@ -270,9 +289,11 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.workerGroups[0].podSecurityContext.runAsNonRoot | bool | `false` | run explicitly as a non-root user. The default is false. |
 | windmill.workerGroups[0].podSecurityContext.runAsUser | int | `0` | run as user. The default is 0 for root user |
 | windmill.workerGroups[0].privileged | bool | `true` | Needed to use proper OOM killer on k8s v1.32+ and use unshare pid for security reasons. |
+| windmill.workerGroups[0].readinessProbe | object | `{}` | Readiness probe for this worker group. Empty keeps the default, a /ready check on the metrics port, which only exists on enterprise builds, so CE workers get no probe. |
 | windmill.workerGroups[0].replicas | int | `3` |  |
 | windmill.workerGroups[0].resources | object | `{"limits":{"memory":"2Gi"}}` | Resource limits and requests for the pods |
 | windmill.workerGroups[0].serviceAccountName | string | `""` | Falls back to the global service account when not set. |
+| windmill.workerGroups[0].tag | string | `""` | Falls back to windmill.tag (then the chart appVersion) when not set. |
 | windmill.workerGroups[0].terminationGracePeriodSeconds | int | `604800` | If a job is being ran, the container will wait for it to finish before terminating until this grace period |
 | windmill.workerGroups[0].tolerations | list | `[]` | Tolerations to apply to the pods |
 | windmill.workerGroups[0].topologySpreadConstraints | list | `[]` |  |
@@ -281,15 +302,21 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.workerGroups[0].volumes | list | `[]` |  |
 | windmill.workerGroups[1].affinity | object | `{}` | Affinity rules to apply to the pods |
 | windmill.workerGroups[1].annotations | object | `{}` | Annotations to apply to the pods |
+| windmill.workerGroups[1].autoscalingManaged | bool | `false` | `replicas` value above is ignored and the deployment is rendered regardless. |
+| windmill.workerGroups[1].baseUrl | string | `""` | {windmill.baseProtocol}://{windmill.baseDomain} when not set. |
 | windmill.workerGroups[1].containerSecurityContext | object | `{}` | Security context to apply to the pod |
 | windmill.workerGroups[1].controller | string | `"Deployment"` | Controller to use. Valid options are "Deployment" and "StatefulSet" |
+| windmill.workerGroups[1].databaseUrlSecretKey | string | `""` | Key within databaseUrlSecretName holding the database URL. Defaults to "url" when not set. |
+| windmill.workerGroups[1].databaseUrlSecretName | string | `""` | windmill.databaseUrlSecretName. |
 | windmill.workerGroups[1].deploymentAnnotations | object | `{}` | Annotations to apply to the controller (Deployment/StatefulSet) itself |
 | windmill.workerGroups[1].disableUnsharePid | bool | `false` | Set to true for nodes where user namespaces are disabled (e.g., Bottlerocket AMI with max_user_namespaces=0). |
 | windmill.workerGroups[1].exposeHostDocker | bool | `false` | SECURITY RISK: mounts the host node's Docker socket into this worker group, giving any script author root-equivalent control of the node's Docker daemon. Trusted, single-tenant use only. Prefer the rootless podman runtime (CONTAINER_RUNTIME=podman on a *-full image, non-root) instead. |
 | windmill.workerGroups[1].extraContainers | list | `[]` | Extra sidecar containers |
 | windmill.workerGroups[1].extraEnv | list | `[{"name":"NATIVE_MODE","value":"true"},{"name":"SLEEP_QUEUE","value":"200"}]` | Extra environment variables to apply to the pods |
 | windmill.workerGroups[1].hostAliases | list | `[]` | Host aliases to apply to the pods (overrides global hostAliases if set) |
+| windmill.workerGroups[1].image | string | `""` | Falls back to windmill.image when not set. |
 | windmill.workerGroups[1].labels | object | `{}` | Labels to apply to the pods |
+| windmill.workerGroups[1].livenessProbe | object | `{}` | Liveness probe for this worker group. See windmill.workerGroups[0].livenessProbe. |
 | windmill.workerGroups[1].mode | string | `"worker"` |  |
 | windmill.workerGroups[1].name | string | `"native"` |  |
 | windmill.workerGroups[1].nodeSelector | object | `{}` | Node selector to use for scheduling the pods |
@@ -297,9 +324,11 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.workerGroups[1].podSecurityContext.runAsNonRoot | bool | `false` | run explicitly as a non-root user. The default is false. |
 | windmill.workerGroups[1].podSecurityContext.runAsUser | int | `0` | run as user. The default is 0 for root user |
 | windmill.workerGroups[1].privileged | bool | `false` | Not needed for native workers as they use a different memory management and isolation mechanism. |
+| windmill.workerGroups[1].readinessProbe | object | `{}` | Readiness probe for this worker group. See windmill.workerGroups[0].readinessProbe. |
 | windmill.workerGroups[1].replicas | int | `1` |  |
 | windmill.workerGroups[1].resources | object | `{"limits":{"memory":"2Gi"}}` | Resource limits and requests for the pods |
 | windmill.workerGroups[1].serviceAccountName | string | `""` | Falls back to the global service account when not set. |
+| windmill.workerGroups[1].tag | string | `""` | Falls back to windmill.tag (then the chart appVersion) when not set. |
 | windmill.workerGroups[1].tolerations | list | `[]` | Tolerations to apply to the pods |
 | windmill.workerGroups[1].topologySpreadConstraints | list | `[]` |  |
 | windmill.workerGroups[1].volumeClaimTemplates | list | `[]` | Volume claim templates. Only applies when controller is "StatefulSet" |
@@ -307,15 +336,20 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.workerGroups[1].volumes | list | `[]` |  |
 | windmill.workerGroups[2].affinity | object | `{}` | Affinity rules to apply to the pods |
 | windmill.workerGroups[2].annotations | object | `{}` | Annotations to apply to the pods |
+| windmill.workerGroups[2].baseUrl | string | `""` | {windmill.baseProtocol}://{windmill.baseDomain} when not set. |
 | windmill.workerGroups[2].command | list | `[]` | command override |
 | windmill.workerGroups[2].containerSecurityContext | object | `{}` | Security context to apply to the pod |
 | windmill.workerGroups[2].controller | string | `"Deployment"` | Controller to use. Valid options are "Deployment" and "StatefulSet" |
+| windmill.workerGroups[2].databaseUrlSecretKey | string | `""` | Key within databaseUrlSecretName holding the database URL. Defaults to "url" when not set. |
+| windmill.workerGroups[2].databaseUrlSecretName | string | `""` | windmill.databaseUrlSecretName. |
 | windmill.workerGroups[2].disableUnsharePid | bool | `false` | Set to true for nodes where user namespaces are disabled (e.g., Bottlerocket AMI with max_user_namespaces=0). |
 | windmill.workerGroups[2].exposeHostDocker | bool | `false` | SECURITY RISK: mounts the host node's Docker socket into this worker group, giving any script author root-equivalent control of the node's Docker daemon. Trusted, single-tenant use only. Prefer the rootless podman runtime (CONTAINER_RUNTIME=podman on a *-full image, non-root) instead. |
 | windmill.workerGroups[2].extraContainers | list | `[]` | Extra sidecar containers |
 | windmill.workerGroups[2].extraEnv | list | `[]` | Extra environment variables to apply to the pods |
 | windmill.workerGroups[2].hostAliases | list | `[]` | Host aliases to apply to the pods (overrides global hostAliases if set) |
+| windmill.workerGroups[2].image | string | `""` | Falls back to windmill.image when not set. |
 | windmill.workerGroups[2].labels | object | `{}` | Labels to apply to the pods |
+| windmill.workerGroups[2].livenessProbe | object | `{}` | Liveness probe for this worker group. See windmill.workerGroups[0].livenessProbe. |
 | windmill.workerGroups[2].mode | string | `"worker"` |  |
 | windmill.workerGroups[2].name | string | `"gpu"` |  |
 | windmill.workerGroups[2].nodeSelector | object | `{}` | Node selector to use for scheduling the pods |
@@ -323,9 +357,11 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.workerGroups[2].podSecurityContext.runAsNonRoot | bool | `false` | run explicitly as a non-root user. The default is false. |
 | windmill.workerGroups[2].podSecurityContext.runAsUser | int | `0` | run as user. The default is 0 for root user |
 | windmill.workerGroups[2].privileged | bool | `true` | Needed to use proper OOM killer on k8s v1.32+ and use unshare pid for security reasons. |
+| windmill.workerGroups[2].readinessProbe | object | `{}` | Readiness probe for this worker group. See windmill.workerGroups[0].readinessProbe. |
 | windmill.workerGroups[2].replicas | int | `0` |  |
 | windmill.workerGroups[2].resources | object | `{"limits":{"memory":"2Gi"}}` | Resource limits and requests for the pods |
 | windmill.workerGroups[2].serviceAccountName | string | `""` | Falls back to the global service account when not set. |
+| windmill.workerGroups[2].tag | string | `""` | Falls back to windmill.tag (then the chart appVersion) when not set. |
 | windmill.workerGroups[2].tolerations | list | `[]` | Tolerations to apply to the pods |
 | windmill.workerGroups[2].topologySpreadConstraints | list | `[]` |  |
 | windmill.workerGroups[2].volumeClaimTemplates | list | `[]` | Volume claim templates. Only applies when controller is "StatefulSet" |
@@ -362,4 +398,46 @@ windmill:
           name: windmill-postgres
           key: password
 ```
+
+## Keeping the connection string out of the environment
+
+Both approaches above still surface the connection string as a `DATABASE_URL` environment variable in the pod spec, which some compliance baselines disallow regardless of where the value came from. Set `windmill.databaseUrlAsFile` to mount the secret as a file and pass `DATABASE_URL_FILE` instead, so no component renders `DATABASE_URL` at all:
+
+```yaml
+windmill:
+  databaseUrlSecretName: windmill-database-url
+  databaseUrlSecretKey: url
+  databaseUrlAsFile: true
+```
+
+The secret is projected at `windmill.databaseUrlFilePath` (`/etc/windmill/secrets/database-url` by default), read-only, with mode `windmill.databaseUrlFileMode`. Because the mount is an ordinary secret volume, it can equally be backed by the [Secrets Store CSI driver](https://secrets-store-csi-driver.sigs.k8s.io/), Vault Agent or External Secrets, in which case the value reaches a tmpfs in the pod and never lands in etcd.
+
+This applies to the app, worker groups, indexer and operator. The hub is unaffected: it reads `DATABASE_URL` from the environment only.
+
+If the connection string has to be decrypted or fetched by your own tooling first, point `windmill.databaseUrlFilePath` at a shared `emptyDir` and render it from an init container, which is also how Vault Agent and the CSI driver deliver secrets:
+
+```yaml
+windmill:
+  databaseUrlAsFile: true
+  databaseUrlFilePath: /etc/windmill/secrets/database-url
+  app:
+    volumes:
+      - name: dsn
+        emptyDir:
+          medium: Memory
+    volumeMounts:
+      - name: dsn
+        mountPath: /etc/windmill/secrets
+    initContainers:
+      - name: decrypt-dsn
+        image: <an image carrying your secret tooling>
+        command: ["sh", "-c", "sops -d /enc/db.enc > /etc/windmill/secrets/database-url"]
+        volumeMounts:
+          - name: dsn
+            mountPath: /etc/windmill/secrets
+```
+
+Repeat the volume keys for each component you run. With no `databaseUrlSecretName` and no `databaseSecret` the chart mounts nothing of its own at that path, so the volume you supply is the only one there.
+
+If the database credential itself is what you want to eliminate, an AWS RDS or Azure Postgres instance can authenticate the pod's own workload identity instead. Set the password component of the connection string to the sentinel `iamrds` (with `AWS_REGION`) or `entraid` (with `AZURE_TENANT_ID`, `AZURE_CLIENT_ID` and `AZURE_FEDERATED_TOKEN_FILE`) and Windmill Enterprise mints a short-lived token per connection, leaving no long-lived secret to protect.
 

--- a/charts/windmill/README.md
+++ b/charts/windmill/README.md
@@ -140,7 +140,6 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.app.podSecurityContext | object | `{"runAsNonRoot":false,"runAsUser":0}` | Security context to apply to the pods |
 | windmill.app.podSecurityContext.runAsNonRoot | bool | `false` | run explicitly as a non-root user. The default is false. |
 | windmill.app.podSecurityContext.runAsUser | int | `0` | run as user. The default is 0 for root user |
-| windmill.app.readinessProbe | object | `{"failureThreshold":1,"httpGet":{"httpHeaders":[{"name":"Host","value":"localhost"}],"path":"/","port":8000,"scheme":"HTTP"},"initialDelaySeconds":5,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":1}` | Readiness probe for the app pods. Set to {} to remove it. Point it at /api/health/status to also take a pod out of the service when its database connection is unhealthy, at the cost of removing every pod at once during a database outage. |
 | windmill.app.resources | object | `{"limits":{"memory":"2Gi"}}` | Resource limits and requests for the pods |
 | windmill.app.securityContext | object | `{}` | legacy, use podSecurityContext instead |
 | windmill.app.service.annotations | object | `{}` | Annotations to apply to the service |
@@ -207,7 +206,6 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.indexer.podSecurityContext.runAsNonRoot | bool | `false` | run explicitly as a non-root user. The default is false. |
 | windmill.indexer.podSecurityContext.runAsUser | int | `0` | run as user. The default is 0 for root user |
 | windmill.indexer.progressDeadlineSeconds | int | `1800` | How long a rollout may take before Kubernetes reports ProgressDeadlineExceeded. The incoming pod waits for the outgoing one to hand over the index write lock and then loads the index from object storage, so raise this further if your index is large enough that upgrades still time out. |
-| windmill.indexer.readinessProbe | object | `{"failureThreshold":1,"httpGet":{"httpHeaders":[{"name":"Host","value":"localhost"}],"path":"/","port":8000,"scheme":"HTTP"},"initialDelaySeconds":5,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":1}` | Readiness probe for the indexer pods. Set to {} to remove it. |
 | windmill.indexer.resources | object | `{"limits":{"ephemeral-storage":"50Gi","memory":"2Gi"}}` | Resource limits and requests for the pods |
 | windmill.indexer.securityContext | string | `nil` | legacy, use podSecurityContext instead |
 | windmill.indexer.startupProbe | object | `{"failureThreshold":180,"httpGet":{"path":"/api/version","port":8000,"scheme":"HTTP"},"periodSeconds":10,"timeoutSeconds":5}` | Startup probe for the indexer pods. Set to {} to remove it. The indexer loads its index from object storage before it starts serving HTTP, so the liveness probe must stay disabled until that finishes or a large index restarts the pod forever. Keep the budget (periodSeconds x failureThreshold) at least as large as progressDeadlineSeconds. |
@@ -284,7 +282,6 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.workerGroups[0].image | string | `""` | Falls back to windmill.image when not set. |
 | windmill.workerGroups[0].initContainers | list | `[]` | Init containers |
 | windmill.workerGroups[0].labels | object | `{}` | Labels to apply to the pods |
-| windmill.workerGroups[0].livenessProbe | object | `{}` | Liveness probe for this worker group. Empty on purpose: a restart kills the jobs the worker is running, and /ready latches to healthy once the worker has started, so it cannot detect a wedged job loop anyway. Set one only with that trade-off in mind. |
 | windmill.workerGroups[0].mode | string | `"worker"` |  |
 | windmill.workerGroups[0].name | string | `"default"` |  |
 | windmill.workerGroups[0].nodeSelector | object | `{}` | Node selector to use for scheduling the pods |
@@ -292,7 +289,6 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.workerGroups[0].podSecurityContext.runAsNonRoot | bool | `false` | run explicitly as a non-root user. The default is false. |
 | windmill.workerGroups[0].podSecurityContext.runAsUser | int | `0` | run as user. The default is 0 for root user |
 | windmill.workerGroups[0].privileged | bool | `true` | Needed to use proper OOM killer on k8s v1.32+ and use unshare pid for security reasons. |
-| windmill.workerGroups[0].readinessProbe | object | `{}` | Readiness probe for this worker group. Empty keeps the default, a /ready check on the metrics port, which only exists on enterprise builds, so CE workers get no probe. |
 | windmill.workerGroups[0].replicas | int | `3` |  |
 | windmill.workerGroups[0].resources | object | `{"limits":{"memory":"2Gi"}}` | Resource limits and requests for the pods |
 | windmill.workerGroups[0].serviceAccountName | string | `""` | Falls back to the global service account when not set. |
@@ -319,7 +315,6 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.workerGroups[1].hostAliases | list | `[]` | Host aliases to apply to the pods (overrides global hostAliases if set) |
 | windmill.workerGroups[1].image | string | `""` | Falls back to windmill.image when not set. |
 | windmill.workerGroups[1].labels | object | `{}` | Labels to apply to the pods |
-| windmill.workerGroups[1].livenessProbe | object | `{}` | Liveness probe for this worker group. See windmill.workerGroups[0].livenessProbe. |
 | windmill.workerGroups[1].mode | string | `"worker"` |  |
 | windmill.workerGroups[1].name | string | `"native"` |  |
 | windmill.workerGroups[1].nodeSelector | object | `{}` | Node selector to use for scheduling the pods |
@@ -327,7 +322,6 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.workerGroups[1].podSecurityContext.runAsNonRoot | bool | `false` | run explicitly as a non-root user. The default is false. |
 | windmill.workerGroups[1].podSecurityContext.runAsUser | int | `0` | run as user. The default is 0 for root user |
 | windmill.workerGroups[1].privileged | bool | `false` | Not needed for native workers as they use a different memory management and isolation mechanism. |
-| windmill.workerGroups[1].readinessProbe | object | `{}` | Readiness probe for this worker group. See windmill.workerGroups[0].readinessProbe. |
 | windmill.workerGroups[1].replicas | int | `1` |  |
 | windmill.workerGroups[1].resources | object | `{"limits":{"memory":"2Gi"}}` | Resource limits and requests for the pods |
 | windmill.workerGroups[1].serviceAccountName | string | `""` | Falls back to the global service account when not set. |
@@ -352,7 +346,6 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.workerGroups[2].hostAliases | list | `[]` | Host aliases to apply to the pods (overrides global hostAliases if set) |
 | windmill.workerGroups[2].image | string | `""` | Falls back to windmill.image when not set. |
 | windmill.workerGroups[2].labels | object | `{}` | Labels to apply to the pods |
-| windmill.workerGroups[2].livenessProbe | object | `{}` | Liveness probe for this worker group. See windmill.workerGroups[0].livenessProbe. |
 | windmill.workerGroups[2].mode | string | `"worker"` |  |
 | windmill.workerGroups[2].name | string | `"gpu"` |  |
 | windmill.workerGroups[2].nodeSelector | object | `{}` | Node selector to use for scheduling the pods |
@@ -360,7 +353,6 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | windmill.workerGroups[2].podSecurityContext.runAsNonRoot | bool | `false` | run explicitly as a non-root user. The default is false. |
 | windmill.workerGroups[2].podSecurityContext.runAsUser | int | `0` | run as user. The default is 0 for root user |
 | windmill.workerGroups[2].privileged | bool | `true` | Needed to use proper OOM killer on k8s v1.32+ and use unshare pid for security reasons. |
-| windmill.workerGroups[2].readinessProbe | object | `{}` | Readiness probe for this worker group. See windmill.workerGroups[0].readinessProbe. |
 | windmill.workerGroups[2].replicas | int | `0` |  |
 | windmill.workerGroups[2].resources | object | `{"limits":{"memory":"2Gi"}}` | Resource limits and requests for the pods |
 | windmill.workerGroups[2].serviceAccountName | string | `""` | Falls back to the global service account when not set. |

--- a/charts/windmill/README.md
+++ b/charts/windmill/README.md
@@ -88,7 +88,7 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | hub.resources | object | `{"limits":{"memory":"2Gi"}}` | Resource limits and requests for the pods |
 | hub.securityContext | string | `nil` | legacy, use podSecurityContext instead |
 | hub.serviceAccount.name | string | `""` | Name of an existing ServiceAccount to use for the hub pods. If empty, falls back to the chart's main ServiceAccount (see `serviceAccount` at the top level). Set this to bind a dedicated SA for IRSA (EKS) / Workload Identity (GKE). |
-| hub.tag | string | `"1.2.0"` |  |
+| hub.tag | string | `"2.10.0"` |  |
 | hub.tolerations | list | `[]` | Tolerations to apply to the pods |
 | hub.volumeMounts | list | `[]` | volumeMounts |
 | hub.volumes | list | `[]` | volumes |

--- a/charts/windmill/README.md
+++ b/charts/windmill/README.md
@@ -413,7 +413,9 @@ windmill:
   databaseUrlAsFile: true
 ```
 
-The secret is projected at `windmill.databaseUrlFilePath` (`/etc/windmill/secrets/database-url` by default), read-only, with mode `windmill.databaseUrlFileMode`. Because the mount is an ordinary secret volume, it can equally be backed by the [Secrets Store CSI driver](https://secrets-store-csi-driver.sigs.k8s.io/), Vault Agent or External Secrets, in which case the value reaches a tmpfs in the pod and never lands in etcd.
+The secret is projected at `windmill.databaseUrlFilePath` (`/etc/windmill/secrets/database-url` by default), read-only, with mode `windmill.databaseUrlFileMode`.
+
+That still consumes a Kubernetes Secret, which lives in etcd unless the cluster encrypts Secrets at rest. To keep the connection string out of etcd entirely, leave `databaseUrlSecretName` and `databaseSecret` unset so the chart mounts nothing of its own, and deliver the file with a volume of your own: the [Secrets Store CSI driver](https://secrets-store-csi-driver.sigs.k8s.io/) without secret syncing, or Vault Agent injection, both write it to a tmpfs in the pod without creating a Secret object. External Secrets is not one of these: it materialises a Kubernetes Secret, so it belongs in the first form above.
 
 This applies to the app, worker groups, indexer and operator. The hub is unaffected: it reads `DATABASE_URL` from the environment only.
 

--- a/charts/windmill/README.md.gotmpl
+++ b/charts/windmill/README.md.gotmpl
@@ -46,4 +46,46 @@ windmill:
           key: password
 ```
 
+## Keeping the connection string out of the environment
+
+Both approaches above still surface the connection string as a `DATABASE_URL` environment variable in the pod spec, which some compliance baselines disallow regardless of where the value came from. Set `windmill.databaseUrlAsFile` to mount the secret as a file and pass `DATABASE_URL_FILE` instead, so no component renders `DATABASE_URL` at all:
+
+```yaml
+windmill:
+  databaseUrlSecretName: windmill-database-url
+  databaseUrlSecretKey: url
+  databaseUrlAsFile: true
+```
+
+The secret is projected at `windmill.databaseUrlFilePath` (`/etc/windmill/secrets/database-url` by default), read-only, with mode `windmill.databaseUrlFileMode`. Because the mount is an ordinary secret volume, it can equally be backed by the [Secrets Store CSI driver](https://secrets-store-csi-driver.sigs.k8s.io/), Vault Agent or External Secrets, in which case the value reaches a tmpfs in the pod and never lands in etcd.
+
+This applies to the app, worker groups, indexer and operator. The hub is unaffected: it reads `DATABASE_URL` from the environment only.
+
+If the connection string has to be decrypted or fetched by your own tooling first, point `windmill.databaseUrlFilePath` at a shared `emptyDir` and render it from an init container, which is also how Vault Agent and the CSI driver deliver secrets:
+
+```yaml
+windmill:
+  databaseUrlAsFile: true
+  databaseUrlFilePath: /etc/windmill/secrets/database-url
+  app:
+    volumes:
+      - name: dsn
+        emptyDir:
+          medium: Memory
+    volumeMounts:
+      - name: dsn
+        mountPath: /etc/windmill/secrets
+    initContainers:
+      - name: decrypt-dsn
+        image: <an image carrying your secret tooling>
+        command: ["sh", "-c", "sops -d /enc/db.enc > /etc/windmill/secrets/database-url"]
+        volumeMounts:
+          - name: dsn
+            mountPath: /etc/windmill/secrets
+```
+
+Repeat the volume keys for each component you run. With no `databaseUrlSecretName` and no `databaseSecret` the chart mounts nothing of its own at that path, so the volume you supply is the only one there.
+
+If the database credential itself is what you want to eliminate, an AWS RDS or Azure Postgres instance can authenticate the pod's own workload identity instead. Set the password component of the connection string to the sentinel `iamrds` (with `AWS_REGION`) or `entraid` (with `AZURE_TENANT_ID`, `AZURE_CLIENT_ID` and `AZURE_FEDERATED_TOKEN_FILE`) and Windmill Enterprise mints a short-lived token per connection, leaving no long-lived secret to protect.
+
 {{ template "helm-docs.versionFooter" . }}

--- a/charts/windmill/README.md.gotmpl
+++ b/charts/windmill/README.md.gotmpl
@@ -57,7 +57,9 @@ windmill:
   databaseUrlAsFile: true
 ```
 
-The secret is projected at `windmill.databaseUrlFilePath` (`/etc/windmill/secrets/database-url` by default), read-only, with mode `windmill.databaseUrlFileMode`. Because the mount is an ordinary secret volume, it can equally be backed by the [Secrets Store CSI driver](https://secrets-store-csi-driver.sigs.k8s.io/), Vault Agent or External Secrets, in which case the value reaches a tmpfs in the pod and never lands in etcd.
+The secret is projected at `windmill.databaseUrlFilePath` (`/etc/windmill/secrets/database-url` by default), read-only, with mode `windmill.databaseUrlFileMode`.
+
+That still consumes a Kubernetes Secret, which lives in etcd unless the cluster encrypts Secrets at rest. To keep the connection string out of etcd entirely, leave `databaseUrlSecretName` and `databaseSecret` unset so the chart mounts nothing of its own, and deliver the file with a volume of your own: the [Secrets Store CSI driver](https://secrets-store-csi-driver.sigs.k8s.io/) without secret syncing, or Vault Agent injection, both write it to a tmpfs in the pod without creating a Secret object. External Secrets is not one of these: it materialises a Kubernetes Secret, so it belongs in the first form above.
 
 This applies to the app, worker groups, indexer and operator. The hub is unaffected: it reads `DATABASE_URL` from the environment only.
 

--- a/charts/windmill/ci/database-url-file-values.yaml
+++ b/charts/windmill/ci/database-url-file-values.yaml
@@ -1,0 +1,9 @@
+# Installs with the database url consumed from a mounted file rather than a DATABASE_URL
+# env var. Every other ci values file leaves databaseUrlAsFile off, so without this one the
+# file path is only ever covered by rendering, and a pod that cannot read the mounted secret
+# still installs green.
+windmill:
+  # Has the chart create the windmill-database secret from windmill.databaseUrl, giving
+  # databaseUrlAsFile a secret to project.
+  databaseSecret: true
+  databaseUrlAsFile: true

--- a/charts/windmill/templates/_helpers.tpl
+++ b/charts/windmill/templates/_helpers.tpl
@@ -115,6 +115,93 @@ Usage:
     {{- end }}
 {{- end -}}
 
+{{/*
+Name of the secret holding the database url, or empty when the url is only configured as a
+literal. Worker groups may point at another instance's database, so their own secret wins.
+Usage: {{ include "windmill.databaseUrlSecretName" (dict "root" $ "override" $v) }}
+*/}}
+{{- define "windmill.databaseUrlSecretName" -}}
+{{- $override := .override | default dict -}}
+{{- if $override.databaseUrlSecretName -}}
+{{- $override.databaseUrlSecretName -}}
+{{- else if .root.Values.windmill.databaseSecret -}}
+windmill-database
+{{- else if .root.Values.windmill.databaseUrlSecretName -}}
+{{- .root.Values.windmill.databaseUrlSecretName -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Key within the secret resolved by windmill.databaseUrlSecretName.
+*/}}
+{{- define "windmill.databaseUrlSecretKey" -}}
+{{- $override := .override | default dict -}}
+{{- if $override.databaseUrlSecretName -}}
+{{- default "url" $override.databaseUrlSecretKey -}}
+{{- else if .root.Values.windmill.databaseSecret -}}
+url
+{{- else if .root.Values.windmill.databaseUrlSecretName -}}
+{{- default "url" .root.Values.windmill.databaseUrlSecretKey -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Database url env entry for a windmill component. With databaseUrlAsFile the connection
+string is read from a mounted secret file and no DATABASE_URL is rendered at all, so it
+never appears in the pod spec. The backend prefers DATABASE_URL_FILE over DATABASE_URL.
+Not for the hub, which reads DATABASE_URL from the environment only.
+Usage: {{- include "windmill.databaseUrlEnv" (dict "root" $ "override" $v) | nindent 8 }}
+*/}}
+{{- define "windmill.databaseUrlEnv" -}}
+{{- $secretName := include "windmill.databaseUrlSecretName" . -}}
+{{- if .root.Values.windmill.databaseUrlAsFile -}}
+{{- if not (hasPrefix "/" .root.Values.windmill.databaseUrlFilePath) -}}
+{{- fail "windmill.databaseUrlFilePath must be an absolute path: its directory becomes the mount point" -}}
+{{- end -}}
+- name: "DATABASE_URL_FILE"
+  value: "{{ .root.Values.windmill.databaseUrlFilePath }}"
+{{- else if $secretName }}
+- name: "DATABASE_URL"
+  valueFrom:
+    secretKeyRef:
+      name: "{{ $secretName }}"
+      key: "{{ include "windmill.databaseUrlSecretKey" . }}"
+{{- else }}
+- name: "DATABASE_URL"
+  value: "{{ .root.Values.windmill.databaseUrl }}"
+{{- end -}}
+{{- end -}}
+
+{{/*
+Volume mount for the database url file. Renders nothing when the url is not in a secret:
+the file is then supplied by the deployment itself (an init container, a CSI driver), and
+mounting anything here would collide with the volume it already mounts at that path.
+*/}}
+{{- define "windmill.databaseUrlVolumeMount" -}}
+{{- if and .root.Values.windmill.databaseUrlAsFile (include "windmill.databaseUrlSecretName" .) -}}
+- name: windmill-database-url
+  mountPath: {{ dir .root.Values.windmill.databaseUrlFilePath | quote }}
+  readOnly: true
+{{- end -}}
+{{- end -}}
+
+{{/*
+Volume projecting the database url secret at databaseUrlFilePath. The key is projected onto
+a fixed filename so the path stays the one the operator configured, whatever the secret key
+is called.
+*/}}
+{{- define "windmill.databaseUrlVolume" -}}
+{{- if and .root.Values.windmill.databaseUrlAsFile (include "windmill.databaseUrlSecretName" .) -}}
+- name: windmill-database-url
+  secret:
+    secretName: {{ include "windmill.databaseUrlSecretName" . | quote }}
+    defaultMode: {{ .root.Values.windmill.databaseUrlFileMode }}
+    items:
+      - key: {{ include "windmill.databaseUrlSecretKey" . | quote }}
+        path: {{ base .root.Values.windmill.databaseUrlFilePath | quote }}
+{{- end -}}
+{{- end -}}
+
 {{/*   Routing exclusivity check   */}}
 {{- if and .Values.httproute.enabled .Values.ingress.enabled }}
 {{- fail "Both ingress.enabled and httproute.enabled are true. Disable one to avoid conflicts." }}

--- a/charts/windmill/templates/app.yaml
+++ b/charts/windmill/templates/app.yaml
@@ -99,10 +99,19 @@ spec:
         startupProbe:
         {{- toYaml . | nindent 10 }}
         {{- end }}
-        {{- with .Values.windmill.app.readinessProbe }}
         readinessProbe:
-        {{- toYaml . | nindent 10 }}
-        {{- end }}
+          timeoutSeconds: 1
+          successThreshold: 1
+          failureThreshold: 1
+          httpGet:
+            scheme: HTTP
+            path: /
+            httpHeaders:
+            - name: Host
+              value: localhost
+            port: 8000
+          initialDelaySeconds: 5
+          periodSeconds: 5
         {{- with .Values.windmill.app.livenessProbe }}
         livenessProbe:
         {{- toYaml . | nindent 10 }}

--- a/charts/windmill/templates/app.yaml
+++ b/charts/windmill/templates/app.yaml
@@ -80,7 +80,7 @@ spec:
         image: {{ default "ghcr.io/windmill-labs/windmill" .Values.windmill.image }}:{{ default .Chart.AppVersion .Values.windmill.tag }}
         {{ end }}
         imagePullPolicy: {{ default "Always" $.Values.windmill.imagePullPolicy }}
-        {{ if or .Values.windmill.app.volumeMounts .Values.windmill.app.smtpTls.enabled }}
+        {{ if or .Values.windmill.app.volumeMounts .Values.windmill.app.smtpTls.enabled .Values.windmill.databaseUrlAsFile }}
         volumeMounts:
         {{- with .Values.windmill.app.volumeMounts }}
         {{ toYaml . | nindent 8 }}
@@ -90,23 +90,19 @@ spec:
           mountPath: /etc/windmill/smtp-tls
           readOnly: true
         {{ end }}
+        {{- include "windmill.databaseUrlVolumeMount" (dict "root" $) | nindent 8 }}
         {{ end }}
         ports:
         - containerPort: 8000
         - containerPort: 8001
+        {{- with .Values.windmill.app.readinessProbe }}
         readinessProbe:
-          timeoutSeconds: 1
-          successThreshold: 1
-          failureThreshold: 1
-          httpGet:
-            scheme: HTTP
-            path: /
-            httpHeaders:
-            - name: Host
-              value: localhost
-            port: 8000
-          initialDelaySeconds: 5
-          periodSeconds: 5
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.windmill.app.livenessProbe }}
+        livenessProbe:
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
         env:
         {{- with .Values.windmill.app.extraEnv }}
         {{- toYaml . | nindent 8 }}
@@ -119,22 +115,7 @@ spec:
         - name : "METRICS_ADDR"
           value: "{{ .Values.enterprise.metricsAddr }}"
         {{ end }}
-        {{ if .Values.windmill.databaseSecret }}
-        - name: "DATABASE_URL"
-          valueFrom:
-            secretKeyRef:
-              name: "windmill-database"
-              key: "url"
-        {{ else if .Values.windmill.databaseUrlSecretName }}
-        - name: "DATABASE_URL"
-          valueFrom:
-            secretKeyRef:
-              name: "{{ .Values.windmill.databaseUrlSecretName }}"
-              key: "{{ .Values.windmill.databaseUrlSecretKey }}"
-        {{ else }}
-        - name: "DATABASE_URL"
-          value: "{{ .Values.windmill.databaseUrl }}"
-        {{ end }}
+        {{- include "windmill.databaseUrlEnv" (dict "root" $) | nindent 8 }}
         - name: "BASE_URL"
           value: "{{ .Values.windmill.baseProtocol }}://{{ .Values.windmill.baseDomain }}"
         - name: "RUST_LOG"
@@ -197,7 +178,7 @@ spec:
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{ if or .Values.windmill.app.volumes .Values.windmill.app.smtpTls.enabled }}
+    {{ if or .Values.windmill.app.volumes .Values.windmill.app.smtpTls.enabled .Values.windmill.databaseUrlAsFile }}
       volumes:
       {{- with .Values.windmill.app.volumes }}
 {{ toYaml . | indent 8 }}
@@ -207,6 +188,7 @@ spec:
           secret:
             secretName: {{ .Values.windmill.app.smtpTls.certSecretName }}
       {{ end }}
+      {{- include "windmill.databaseUrlVolume" (dict "root" $) | nindent 8 }}
     {{ end }}
     {{- with .Values.windmill.app.affinity }}
       affinity:

--- a/charts/windmill/templates/app.yaml
+++ b/charts/windmill/templates/app.yaml
@@ -95,10 +95,16 @@ spec:
         ports:
         - containerPort: 8000
         - containerPort: 8001
-        {{- with .Values.windmill.app.startupProbe }}
+        # Holds the liveness probe off until the process serves HTTP, which it does not do
+        # while a migration runs on upgrade.
         startupProbe:
-        {{- toYaml . | nindent 10 }}
-        {{- end }}
+          httpGet:
+            scheme: HTTP
+            path: /api/version
+            port: 8000
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 60
         readinessProbe:
           timeoutSeconds: 1
           successThreshold: 1
@@ -112,10 +118,16 @@ spec:
             port: 8000
           initialDelaySeconds: 5
           periodSeconds: 5
-        {{- with .Values.windmill.app.livenessProbe }}
+        # /api/version touches no dependency, so only a wedged process fails this. A probe
+        # reading the database would restart every pod at once during a database outage.
         livenessProbe:
-        {{- toYaml . | nindent 10 }}
-        {{- end }}
+          httpGet:
+            scheme: HTTP
+            path: /api/version
+            port: 8000
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 6
         env:
         {{- with .Values.windmill.app.extraEnv }}
         {{- toYaml . | nindent 8 }}

--- a/charts/windmill/templates/hub.yaml
+++ b/charts/windmill/templates/hub.yaml
@@ -61,14 +61,24 @@ spec:
         imagePullPolicy: {{ default "Always" $.Values.windmill.imagePullPolicy }}
         ports:
         - containerPort: 3000
-        {{- with .Values.hub.readinessProbe }}
         readinessProbe:
-        {{- toYaml . | nindent 10 }}
-        {{- end }}
-        {{- with .Values.hub.livenessProbe }}
+          httpGet:
+            scheme: HTTP
+            path: /ready
+            port: 3000
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        # A socket check rather than /ready, which reports 503 while the embeddings database
+        # loads: a slow load is not a reason to restart the pod.
         livenessProbe:
-        {{- toYaml . | nindent 10 }}
-        {{- end }}
+          tcpSocket:
+            port: 3000
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 6
         env:
         {{- with .Values.hub.extraEnv }}
         {{- toYaml . | nindent 8 }}

--- a/charts/windmill/templates/hub.yaml
+++ b/charts/windmill/templates/hub.yaml
@@ -61,6 +61,14 @@ spec:
         imagePullPolicy: {{ default "Always" $.Values.windmill.imagePullPolicy }}
         ports:
         - containerPort: 3000
+        {{- with .Values.hub.readinessProbe }}
+        readinessProbe:
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.hub.livenessProbe }}
+        livenessProbe:
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
         env:
         {{- with .Values.hub.extraEnv }}
         {{- toYaml . | nindent 8 }}

--- a/charts/windmill/templates/indexer.yaml
+++ b/charts/windmill/templates/indexer.yaml
@@ -60,21 +60,23 @@ spec:
       {{- end }}
         image: {{ default "ghcr.io/windmill-labs/windmill-ee" .Values.windmill.image }}:{{ default .Chart.AppVersion .Values.windmill.tag }}
         imagePullPolicy: {{ default "Always" $.Values.windmill.imagePullPolicy }}
+        {{ if or .Values.windmill.indexer.volumeMounts .Values.windmill.databaseUrlAsFile }}
+        volumeMounts:
+        {{- with .Values.windmill.indexer.volumeMounts }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+        {{- include "windmill.databaseUrlVolumeMount" (dict "root" $) | nindent 8 }}
+        {{ end }}
         ports:
         - containerPort: 8000
+        {{- with .Values.windmill.indexer.readinessProbe }}
         readinessProbe:
-          timeoutSeconds: 1
-          successThreshold: 1
-          failureThreshold: 1
-          httpGet:
-            scheme: HTTP
-            path: /
-            httpHeaders:
-            - name: Host
-              value: localhost
-            port: 8000
-          initialDelaySeconds: 5
-          periodSeconds: 5
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.windmill.indexer.livenessProbe }}
+        livenessProbe:
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
         env:
         {{- with .Values.windmill.indexer.extraEnv }}
         {{- toYaml . | nindent 8 }}
@@ -83,22 +85,7 @@ spec:
         - name : "METRICS_ADDR"
           value: "{{ .Values.enterprise.metricsAddr }}"
         {{ end }}
-        {{ if .Values.windmill.databaseSecret }}
-        - name: "DATABASE_URL"
-          valueFrom:
-            secretKeyRef:
-              name: "windmill-database"
-              key: "url"
-        {{ else if .Values.windmill.databaseUrlSecretName }}
-        - name: "DATABASE_URL"
-          valueFrom:
-            secretKeyRef:
-              name: "{{ .Values.windmill.databaseUrlSecretName }}"
-              key: "{{ .Values.windmill.databaseUrlSecretKey }}"
-        {{ else }}
-        - name: "DATABASE_URL"
-          value: "{{ .Values.windmill.databaseUrl }}"
-        {{ end }}
+        {{- include "windmill.databaseUrlEnv" (dict "root" $) | nindent 8 }}
         - name: "BASE_URL"
           value: "{{ .Values.windmill.baseProtocol }}://{{ .Values.windmill.baseDomain }}"
         - name: "RUST_LOG"
@@ -133,6 +120,13 @@ spec:
         {{ end }}
         resources:
 {{ toYaml .Values.windmill.indexer.resources | indent 12 }}
+    {{ if or .Values.windmill.indexer.volumes .Values.windmill.databaseUrlAsFile }}
+      volumes:
+      {{- with .Values.windmill.indexer.volumes }}
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- include "windmill.databaseUrlVolume" (dict "root" $) | nindent 8 }}
+    {{ end }}
     {{- with .Values.windmill.indexer.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/charts/windmill/templates/indexer.yaml
+++ b/charts/windmill/templates/indexer.yaml
@@ -81,10 +81,19 @@ spec:
         startupProbe:
         {{- toYaml . | nindent 10 }}
         {{- end }}
-        {{- with .Values.windmill.indexer.readinessProbe }}
         readinessProbe:
-        {{- toYaml . | nindent 10 }}
-        {{- end }}
+          timeoutSeconds: 1
+          successThreshold: 1
+          failureThreshold: 1
+          httpGet:
+            scheme: HTTP
+            path: /
+            httpHeaders:
+            - name: Host
+              value: localhost
+            port: 8000
+          initialDelaySeconds: 5
+          periodSeconds: 5
         {{- with .Values.windmill.indexer.livenessProbe }}
         livenessProbe:
         {{- toYaml . | nindent 10 }}

--- a/charts/windmill/templates/indexer.yaml
+++ b/charts/windmill/templates/indexer.yaml
@@ -77,10 +77,17 @@ spec:
         {{ end }}
         ports:
         - containerPort: 8000
-        {{- with .Values.windmill.indexer.startupProbe }}
+        # The indexer loads its index from object storage before it serves HTTP, so the
+        # liveness probe has to stay off until that finishes or a large index restarts the
+        # pod forever. Same wait progressDeadlineSeconds covers, so it tracks that budget.
         startupProbe:
-        {{- toYaml . | nindent 10 }}
-        {{- end }}
+          httpGet:
+            scheme: HTTP
+            path: /api/version
+            port: 8000
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: {{ max 1 (div (.Values.windmill.indexer.progressDeadlineSeconds | default 1800) 10) }}
         readinessProbe:
           timeoutSeconds: 1
           successThreshold: 1
@@ -94,10 +101,14 @@ spec:
             port: 8000
           initialDelaySeconds: 5
           periodSeconds: 5
-        {{- with .Values.windmill.indexer.livenessProbe }}
         livenessProbe:
-        {{- toYaml . | nindent 10 }}
-        {{- end }}
+          httpGet:
+            scheme: HTTP
+            path: /api/version
+            port: 8000
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 6
         env:
         {{- with .Values.windmill.indexer.extraEnv }}
         {{- toYaml . | nindent 8 }}

--- a/charts/windmill/templates/operator.yaml
+++ b/charts/windmill/templates/operator.yaml
@@ -60,32 +60,31 @@ spec:
         {{ end }}
         imagePullPolicy: {{ default "Always" $.Values.windmill.imagePullPolicy }}
         command: ["windmill", "operator"]
+        {{ if or .Values.windmill.operator.volumeMounts .Values.windmill.databaseUrlAsFile }}
+        volumeMounts:
+        {{- with .Values.windmill.operator.volumeMounts }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+        {{- include "windmill.databaseUrlVolumeMount" (dict "root" $) | nindent 8 }}
+        {{ end }}
         env:
         {{- with .Values.windmill.operator.extraEnv }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{ if .Values.windmill.databaseSecret }}
-        - name: "DATABASE_URL"
-          valueFrom:
-            secretKeyRef:
-              name: "windmill-database"
-              key: "url"
-        {{ else if .Values.windmill.databaseUrlSecretName }}
-        - name: "DATABASE_URL"
-          valueFrom:
-            secretKeyRef:
-              name: "{{ .Values.windmill.databaseUrlSecretName }}"
-              key: "{{ .Values.windmill.databaseUrlSecretKey }}"
-        {{ else }}
-        - name: "DATABASE_URL"
-          value: "{{ .Values.windmill.databaseUrl }}"
-        {{ end }}
+        {{- include "windmill.databaseUrlEnv" (dict "root" $) | nindent 8 }}
         - name: "RUST_LOG"
           value: "{{ .Values.windmill.rustLog }}"
         - name: "JSON_FMT"
           value: "true"
         resources:
 {{ toYaml .Values.windmill.operator.resources | indent 12 }}
+    {{ if or .Values.windmill.operator.volumes .Values.windmill.databaseUrlAsFile }}
+      volumes:
+      {{- with .Values.windmill.operator.volumes }}
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- include "windmill.databaseUrlVolume" (dict "root" $) | nindent 8 }}
+    {{ end }}
     {{- with .Values.windmill.operator.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/charts/windmill/templates/worker-groups.yaml
+++ b/charts/windmill/templates/worker-groups.yaml
@@ -155,7 +155,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         {{ end }}
-        {{- include "windmill.databaseUrlVolumeMount" (dict "root" $) | nindent 8 }}
+        {{- include "windmill.databaseUrlVolumeMount" (dict "root" $ "override" $v) | nindent 8 }}
         env:
         {{- with $v.extraEnv }}
         {{- toYaml . | nindent 8 }}

--- a/charts/windmill/templates/worker-groups.yaml
+++ b/charts/windmill/templates/worker-groups.yaml
@@ -126,7 +126,10 @@ spec:
         {{ end }}
         ports:
         - containerPort: 8001
-        {{ if $.Values.enterprise.enabled }}
+        {{- if $v.readinessProbe }}
+        readinessProbe:
+        {{- toYaml $v.readinessProbe | nindent 10 }}
+        {{- else if $.Values.enterprise.enabled }}
         readinessProbe:
           initialDelaySeconds: 1
           periodSeconds: 5
@@ -137,7 +140,11 @@ spec:
             scheme: HTTP
             path: /ready
             port: 8001
-        {{ end }}
+        {{- end }}
+        {{- with $v.livenessProbe }}
+        livenessProbe:
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
         {{ if or $.Values.windmill.exposeHostDocker $v.exposeHostDocker }}
         - name: docker-sock
@@ -148,6 +155,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         {{ end }}
+        {{- include "windmill.databaseUrlVolumeMount" (dict "root" $) | nindent 8 }}
         env:
         {{- with $v.extraEnv }}
         {{- toYaml . | nindent 8 }}
@@ -156,28 +164,7 @@ spec:
         - name : "METRICS_ADDR"
           value: "{{ $.Values.enterprise.metricsAddr }}"
         {{ end }}
-        {{ if $v.databaseUrlSecretName }}
-        - name: "DATABASE_URL"
-          valueFrom:
-            secretKeyRef:
-              name: "{{ $v.databaseUrlSecretName }}"
-              key: "{{ default "url" $v.databaseUrlSecretKey }}"
-        {{ else if $.Values.windmill.databaseSecret }}
-        - name: "DATABASE_URL"
-          valueFrom:
-            secretKeyRef:
-              name: "windmill-database"
-              key: "url"
-        {{ else if $.Values.windmill.databaseUrlSecretName }}
-        - name: "DATABASE_URL"
-          valueFrom:
-            secretKeyRef:
-              name: "{{ $.Values.windmill.databaseUrlSecretName }}"
-              key: "{{ $.Values.windmill.databaseUrlSecretKey }}"
-        {{ else }}
-        - name: "DATABASE_URL"
-          value: "{{ $.Values.windmill.databaseUrl }}"
-        {{ end }}
+        {{- include "windmill.databaseUrlEnv" (dict "root" $ "override" $v) | nindent 8 }}
         - name: "BASE_URL"
           value: "{{ if $v.baseUrl }}{{ $v.baseUrl }}{{ else }}{{ $.Values.windmill.baseProtocol }}://{{ $.Values.windmill.baseDomain }}{{ end }}"
         - name: "RUST_LOG"
@@ -240,6 +227,7 @@ spec:
     {{- with $v.volumes }}
     {{ toYaml . | nindent 6 }}
     {{- end }}
+    {{- include "windmill.databaseUrlVolume" (dict "root" $ "override" $v) | nindent 6 }}
     {{- with $v.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/charts/windmill/templates/worker-groups.yaml
+++ b/charts/windmill/templates/worker-groups.yaml
@@ -126,10 +126,7 @@ spec:
         {{ end }}
         ports:
         - containerPort: 8001
-        {{- if $v.readinessProbe }}
-        readinessProbe:
-        {{- toYaml $v.readinessProbe | nindent 10 }}
-        {{- else if $.Values.enterprise.enabled }}
+        {{ if $.Values.enterprise.enabled }}
         readinessProbe:
           initialDelaySeconds: 1
           periodSeconds: 5
@@ -140,11 +137,7 @@ spec:
             scheme: HTTP
             path: /ready
             port: 8001
-        {{- end }}
-        {{- with $v.livenessProbe }}
-        livenessProbe:
-        {{- toYaml . | nindent 10 }}
-        {{- end }}
+        {{ end }}
         volumeMounts:
         {{ if or $.Values.windmill.exposeHostDocker $v.exposeHostDocker }}
         - name: docker-sock

--- a/charts/windmill/values.yaml
+++ b/charts/windmill/values.yaml
@@ -422,27 +422,6 @@ windmill:
 
   # app configuration
   app:
-    # -- Startup probe for the app pods. Set to {} to remove it. It keeps the liveness probe disabled until the process serves HTTP, which it does not do while a long migration runs on upgrade. Without it a slow migration would restart every pod before it ever came up.
-    startupProbe:
-      httpGet:
-        scheme: HTTP
-        path: /api/version
-        port: 8000
-      periodSeconds: 10
-      timeoutSeconds: 5
-      failureThreshold: 60
-
-    # -- Liveness probe for the app pods. Set to {} to remove it. /api/version is a static handler that touches no dependency, so only a wedged process fails it: a probe that depended on the database would restart every pod at once during a database outage.
-    livenessProbe:
-      httpGet:
-        scheme: HTTP
-        path: /api/version
-        port: 8000
-      initialDelaySeconds: 30
-      periodSeconds: 10
-      timeoutSeconds: 5
-      failureThreshold: 6
-
     # -- Annotations to apply to the pods
     annotations: {}
 
@@ -579,27 +558,6 @@ windmill:
     # then loads the index from object storage, so raise this further if your index is
     # large enough that upgrades still time out.
     progressDeadlineSeconds: 1800
-
-    # -- Startup probe for the indexer pods. Set to {} to remove it. The indexer loads its index from object storage before it starts serving HTTP, so the liveness probe must stay disabled until that finishes or a large index restarts the pod forever. Keep the budget (periodSeconds x failureThreshold) at least as large as progressDeadlineSeconds.
-    startupProbe:
-      httpGet:
-        scheme: HTTP
-        path: /api/version
-        port: 8000
-      periodSeconds: 10
-      timeoutSeconds: 5
-      failureThreshold: 180
-
-    # -- Liveness probe for the indexer pods. Set to {} to remove it. See windmill.app.livenessProbe for why this deliberately does not check the database.
-    livenessProbe:
-      httpGet:
-        scheme: HTTP
-        path: /api/version
-        port: 8000
-      initialDelaySeconds: 30
-      periodSeconds: 10
-      timeoutSeconds: 5
-      failureThreshold: 6
 
     # -- Extra volumes to add to the pods
     volumes: []
@@ -845,26 +803,6 @@ serviceAccount:
 hub:
   # -- enable Windmill Hub, requires Windmill Enterprise and license key
   enabled: false
-
-  # -- Readiness probe for the hub pods. Set to {} to remove it. /ready reports 503 until the embeddings database has finished loading, which can take a while on a cold start.
-  readinessProbe:
-    httpGet:
-      scheme: HTTP
-      path: /ready
-      port: 3000
-    initialDelaySeconds: 10
-    periodSeconds: 10
-    timeoutSeconds: 5
-    failureThreshold: 3
-
-  # -- Liveness probe for the hub pods. Set to {} to remove it. Deliberately a socket check rather than /ready: a slow embeddings load is not a reason to restart the pod.
-  livenessProbe:
-    tcpSocket:
-      port: 3000
-    initialDelaySeconds: 30
-    periodSeconds: 10
-    timeoutSeconds: 5
-    failureThreshold: 6
   # -- enterprise license key, deprecated use the enterprise values instead
   licenseKey: ""
   # -- replicas for the hub

--- a/charts/windmill/values.yaml
+++ b/charts/windmill/values.yaml
@@ -116,11 +116,6 @@ windmill:
       # -- Controller to use. Valid options are "Deployment" and "StatefulSet"
       controller: "Deployment"
 
-      # -- Readiness probe for this worker group. Empty keeps the default, a /ready check on the metrics port, which only exists on enterprise builds, so CE workers get no probe.
-      readinessProbe: {}
-      # -- Liveness probe for this worker group. Empty on purpose: a restart kills the jobs the worker is running, and /ready latches to healthy once the worker has started, so it cannot detect a wedged job loop anyway. Set one only with that trade-off in mind.
-      livenessProbe: {}
-
       replicas: 3
       # -- Set to true when this worker group's replica count is managed by Windmill's
       # -- native Kubernetes autoscaler. The chart then omits spec.replicas so helm
@@ -237,11 +232,6 @@ windmill:
       # -- Controller to use. Valid options are "Deployment" and "StatefulSet"
       controller: "Deployment"
 
-      # -- Readiness probe for this worker group. See windmill.workerGroups[0].readinessProbe.
-      readinessProbe: {}
-      # -- Liveness probe for this worker group. See windmill.workerGroups[0].livenessProbe.
-      livenessProbe: {}
-
       replicas: 1
       # -- Set to true when this worker group's replica count is managed by Windmill's
       # -- native Kubernetes autoscaler. The chart then omits spec.replicas so helm
@@ -343,11 +333,6 @@ windmill:
       # -- Controller to use. Valid options are "Deployment" and "StatefulSet"
       controller: "Deployment"
 
-      # -- Readiness probe for this worker group. See windmill.workerGroups[0].readinessProbe.
-      readinessProbe: {}
-      # -- Liveness probe for this worker group. See windmill.workerGroups[0].livenessProbe.
-      livenessProbe: {}
-
       replicas: 0
       # -- Annotations to apply to the pods
       annotations: {}
@@ -437,21 +422,6 @@ windmill:
 
   # app configuration
   app:
-    # -- Readiness probe for the app pods. Set to {} to remove it. Point it at /api/health/status to also take a pod out of the service when its database connection is unhealthy, at the cost of removing every pod at once during a database outage.
-    readinessProbe:
-      timeoutSeconds: 1
-      successThreshold: 1
-      failureThreshold: 1
-      httpGet:
-        scheme: HTTP
-        path: /
-        httpHeaders:
-        - name: Host
-          value: localhost
-        port: 8000
-      initialDelaySeconds: 5
-      periodSeconds: 5
-
     # -- Startup probe for the app pods. Set to {} to remove it. It keeps the liveness probe disabled until the process serves HTTP, which it does not do while a long migration runs on upgrade. Without it a slow migration would restart every pod before it ever came up.
     startupProbe:
       httpGet:
@@ -619,21 +589,6 @@ windmill:
       periodSeconds: 10
       timeoutSeconds: 5
       failureThreshold: 180
-
-    # -- Readiness probe for the indexer pods. Set to {} to remove it.
-    readinessProbe:
-      timeoutSeconds: 1
-      successThreshold: 1
-      failureThreshold: 1
-      httpGet:
-        scheme: HTTP
-        path: /
-        httpHeaders:
-        - name: Host
-          value: localhost
-        port: 8000
-      initialDelaySeconds: 5
-      periodSeconds: 5
 
     # -- Liveness probe for the indexer pods. Set to {} to remove it. See windmill.app.livenessProbe for why this deliberately does not check the database.
     livenessProbe:

--- a/charts/windmill/values.yaml
+++ b/charts/windmill/values.yaml
@@ -809,7 +809,7 @@ hub:
   replicas: 1
   # -- image
   image: ""
-  tag: "1.2.0"
+  tag: "2.10.0"
   # -- name of the secret storing the database URI, take precedence over databaseUrl.
   databaseUrlSecretName: ""
   # -- name of the key in secret storing the database URI. The default key of the url is 'url'

--- a/charts/windmill/values.yaml
+++ b/charts/windmill/values.yaml
@@ -51,6 +51,12 @@ windmill:
   databaseUrl: postgres://postgres:windmill@windmill-postgresql/windmill?sslmode=disable
   # -- whether to create a secret containing the value of databaseUrl
   databaseSecret: false
+  # -- read the database URI from a file and set DATABASE_URL_FILE instead of injecting DATABASE_URL into the environment, so the connection string never appears in the pod spec. With databaseUrlSecretName or databaseSecret set, the chart mounts that secret at databaseUrlFilePath; without either, supply the file yourself with a per-component volume (an init container that decrypts it, a CSI driver, Vault Agent). Applies to the app, workers, indexer and operator; the hub reads DATABASE_URL from the environment only and is unaffected.
+  databaseUrlAsFile: false
+  # -- path the database URI is mounted at when databaseUrlAsFile is enabled. Its directory is the mount point, so keep it on a path of its own.
+  databaseUrlFilePath: /etc/windmill/secrets/database-url
+  # -- file mode of the mounted database URI, in octal. 0400 requires the pod to run as the owner of the projected file, so set an fsGroup matching runAsUser alongside it.
+  databaseUrlFileMode: 0444
   # -- domain as shown in browser. url of ths service is at: {baseProtocol}://{baseDomain}
   baseDomain: windmill
   # -- secondary domain that duplicates all ingress routes from baseDomain. Useful for having multiple domains point to the same services.
@@ -109,6 +115,11 @@ windmill:
     - name: "default"
       # -- Controller to use. Valid options are "Deployment" and "StatefulSet"
       controller: "Deployment"
+
+      # -- Readiness probe for this worker group. Empty keeps the default, a /ready check on the metrics port, which only exists on enterprise builds, so CE workers get no probe.
+      readinessProbe: {}
+      # -- Liveness probe for this worker group. Empty on purpose: a restart kills the jobs the worker is running, and /ready latches to healthy once the worker has started, so it cannot detect a wedged job loop anyway. Set one only with that trade-off in mind.
+      livenessProbe: {}
 
       replicas: 3
       # -- Set to true when this worker group's replica count is managed by Windmill's
@@ -226,6 +237,11 @@ windmill:
       # -- Controller to use. Valid options are "Deployment" and "StatefulSet"
       controller: "Deployment"
 
+      # -- Readiness probe for this worker group. See windmill.workerGroups[0].readinessProbe.
+      readinessProbe: {}
+      # -- Liveness probe for this worker group. See windmill.workerGroups[0].livenessProbe.
+      livenessProbe: {}
+
       replicas: 1
       # -- Set to true when this worker group's replica count is managed by Windmill's
       # -- native Kubernetes autoscaler. The chart then omits spec.replicas so helm
@@ -327,6 +343,11 @@ windmill:
       # -- Controller to use. Valid options are "Deployment" and "StatefulSet"
       controller: "Deployment"
 
+      # -- Readiness probe for this worker group. See windmill.workerGroups[0].readinessProbe.
+      readinessProbe: {}
+      # -- Liveness probe for this worker group. See windmill.workerGroups[0].livenessProbe.
+      livenessProbe: {}
+
       replicas: 0
       # -- Annotations to apply to the pods
       annotations: {}
@@ -416,6 +437,32 @@ windmill:
 
   # app configuration
   app:
+    # -- Readiness probe for the app pods. Set to {} to remove it. Point it at /api/health/status to also take a pod out of the service when its database connection is unhealthy, at the cost of removing every pod at once during a database outage.
+    readinessProbe:
+      timeoutSeconds: 1
+      successThreshold: 1
+      failureThreshold: 1
+      httpGet:
+        scheme: HTTP
+        path: /
+        httpHeaders:
+        - name: Host
+          value: localhost
+        port: 8000
+      initialDelaySeconds: 5
+      periodSeconds: 5
+
+    # -- Liveness probe for the app pods. Set to {} to remove it. /api/version is a static handler that touches no dependency, so only a wedged process fails it: a probe that depended on the database would restart every pod at once during a database outage.
+    livenessProbe:
+      httpGet:
+        scheme: HTTP
+        path: /api/version
+        port: 8000
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 6
+
     # -- Annotations to apply to the pods
     annotations: {}
 
@@ -547,6 +594,38 @@ windmill:
     # -- enable or disable indexer
     enabled: true
 
+    # -- Readiness probe for the indexer pods. Set to {} to remove it.
+    readinessProbe:
+      timeoutSeconds: 1
+      successThreshold: 1
+      failureThreshold: 1
+      httpGet:
+        scheme: HTTP
+        path: /
+        httpHeaders:
+        - name: Host
+          value: localhost
+        port: 8000
+      initialDelaySeconds: 5
+      periodSeconds: 5
+
+    # -- Liveness probe for the indexer pods. Set to {} to remove it. See windmill.app.livenessProbe for why this deliberately does not check the database.
+    livenessProbe:
+      httpGet:
+        scheme: HTTP
+        path: /api/version
+        port: 8000
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 6
+
+    # -- Extra volumes to add to the pods
+    volumes: []
+
+    # -- Extra volume mounts to add to the container
+    volumeMounts: []
+
     # -- Annotations to apply to the pods
     annotations: {}
 
@@ -597,6 +676,10 @@ windmill:
     enabled: false
     # -- number of operator replicas (typically 1)
     replicas: 1
+    # -- Extra volumes to add to the pods
+    volumes: []
+    # -- Extra volume mounts to add to the container
+    volumeMounts: []
     # -- instance spec for the operator. When set, the chart creates a ConfigMap
     # -- that the operator watches and syncs to the database. Leave empty/omit to manage it externally.
     # instanceSpec:
@@ -781,6 +864,26 @@ serviceAccount:
 hub:
   # -- enable Windmill Hub, requires Windmill Enterprise and license key
   enabled: false
+
+  # -- Readiness probe for the hub pods. Set to {} to remove it. /ready reports 503 until the embeddings database has finished loading, which can take a while on a cold start.
+  readinessProbe:
+    httpGet:
+      scheme: HTTP
+      path: /ready
+      port: 3000
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+
+  # -- Liveness probe for the hub pods. Set to {} to remove it. Deliberately a socket check rather than /ready: a slow embeddings load is not a reason to restart the pod.
+  livenessProbe:
+    tcpSocket:
+      port: 3000
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
   # -- enterprise license key, deprecated use the enterprise values instead
   licenseKey: ""
   # -- replicas for the hub


### PR DESCRIPTION
## Summary

Two gaps that compliance baselines trip over, both raised by a self-hosted deployment.

`DATABASE_URL` is emitted as an environment variable by every windmill component unconditionally, even when it is sourced from a Kubernetes Secret, so the connection string is always visible in the pod spec. The backend has read the url from a file via `DATABASE_URL_FILE` for a long time, but the chart had no way to use it. `windmill.databaseUrlAsFile` now renders `DATABASE_URL_FILE` instead and mounts the secret at that path, so no component renders `DATABASE_URL` at all.

Separately, the chart has no liveness probes anywhere, and readiness probes on only three of its workloads.

## Changes

- `windmill.databaseUrlAsFile`, `databaseUrlFilePath` and `databaseUrlFileMode`. When a secret is configured (`databaseUrlSecretName` or `databaseSecret`) the chart projects it read-only at that path; without one the deployment supplies the file itself, which is how an init container, Vault Agent or the Secrets Store CSI driver would deliver it. Applies to the app, worker groups, indexer and operator.
- The `DATABASE_URL` env block moved into a `windmill.databaseUrlEnv` helper instead of being copy-pasted across five templates, keeping the existing precedence intact, per-worker-group secret override included.
- `volumes` / `volumeMounts` passthrough on the indexer and operator, which had none, so the file mount can reach them.
- Liveness probes on the app, indexer and hub. The windmill components probe `/api/version`, a static handler that touches no dependency: a probe reading `/api/health/status` would return 503 for every pod at once during a database outage and restart the whole deployment. The hub gets a socket check, since its `/ready` reports 503 while embeddings load.
- Startup probes on the app and indexer, which are what make those liveness probes safe. Neither serves HTTP until it is ready to: the indexer loads its index from object storage first, which `progressDeadlineSeconds` documents can take up to half an hour, and the app waits out any migration on upgrade. Without a startup probe the liveness probe would restart the pod before it ever came up.
- Readiness probe for the hub, which had none, against its existing `/ready` endpoint.
- The probes are hardcoded, adding no values keys: their targets and thresholds are properties of the binaries the chart runs, not deployment choices. The one figure that does vary per deployment is how long the indexer needs before it serves HTTP, and `progressDeadlineSeconds` already covers that same wait, so the startup budget derives from it. Worker groups get no liveness probe at all: a restart kills the jobs in flight, and `/ready` latches to healthy once the worker has started, so it could not detect a wedged job loop anyway.
- The chart README was regenerated with helm-docs and had drifted, so it also picks up a few unrelated description updates.

The operator is the one long-running component still without probes: it runs `windmill operator` with no HTTP listener, so covering it needs a backend change rather than a chart one.

The hub is the one component that cannot use the file mode. It is a SvelteKit app reading `process.env.DATABASE_URL`, not the Rust binary, so it needs a change in the hub repo.

## Test plan

- [x] `helm lint` clean.
- [x] Rendering with default values is unchanged except for the new app probes and the chart version label.
- [x] With `databaseUrlAsFile`, parsing the rendered manifests confirms no `DATABASE_URL` on the app, both worker groups, the indexer or the operator, each with `DATABASE_URL_FILE` and a read-only 0444 secret mount.
- [x] Per-worker-group `databaseUrlSecretName` still wins over the release-global secret in file mode, on Deployment and StatefulSet groups alike.
- [x] A worker group whose secret is configured only on the group, with no release-global secret, gets the volume **and** the mount. This was broken in the first push: the mount helper was not passed the group override, so the volume was declared and never mounted and that worker would have failed to start.
- [x] Without a secret configured, the file mode renders `DATABASE_URL_FILE` and mounts nothing, leaving the path free for a user-supplied volume.
- [x] A relative `databaseUrlFilePath` fails at template time rather than producing an invalid mount.
- [x] Verified against a running backend that `DATABASE_URL_FILE` at that path takes precedence over a `DATABASE_URL` pointing at a nonexistent database, and that `/api/version` and `/api/health/status` both answer 200 unauthenticated.
- [ ] `ct install` in CI covers the default and enterprise value sets; the file mode is not part of either.


