### PR TITLE
chore: default the hub to 2.12.0

### DIFF
--- a/charts/windmill/Chart.yaml
+++ b/charts/windmill/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: windmill
 type: application
-version: 4.0.249
+version: 4.0.250
 appVersion: 1.796.0
 dependencies:
   - condition: minio.enabled

--- a/charts/windmill/README.md
+++ b/charts/windmill/README.md
@@ -89,7 +89,7 @@ Windmill - Turn scripts into endpoints, workflows and UIs in minutes
 | hub.resources | object | `{"limits":{"memory":"2Gi"}}` | Resource limits and requests for the pods |
 | hub.securityContext | string | `nil` | legacy, use podSecurityContext instead |
 | hub.serviceAccount.name | string | `""` | Name of an existing ServiceAccount to use for the hub pods. If empty, falls back to the chart's main ServiceAccount (see `serviceAccount` at the top level). Set this to bind a dedicated SA for IRSA (EKS) / Workload Identity (GKE). |
-| hub.tag | string | `"2.10.0"` |  |
+| hub.tag | string | `"2.12.0"` |  |
 | hub.tolerations | list | `[]` | Tolerations to apply to the pods |
 | hub.volumeMounts | list | `[]` | volumeMounts |
 | hub.volumes | list | `[]` | volumes |

--- a/charts/windmill/values.yaml
+++ b/charts/windmill/values.yaml
@@ -809,7 +809,7 @@ hub:
   replicas: 1
   # -- image
   image: ""
-  tag: "2.10.0"
+  tag: "2.12.0"
   # -- name of the secret storing the database URI, take precedence over databaseUrl.
   databaseUrlSecretName: ""
   # -- name of the key in secret storing the database URI. The default key of the url is 'url'


### PR DESCRIPTION
## Summary

Follow-up to #688. That PR gave the hub its own `hub.databaseUrlAsFile` switch and documented
it as needing hub image 2.12.0 or later, since an older one reads `DATABASE_URL` from the
environment only. The chart default is still 2.10.0, so an operator who follows the docs and
flips the switch without also pinning a newer tag gets a hub with no database configured.
Bumping the default makes the documented requirement true for anyone who has not pinned.

**Blocked on the hub release**: windmill-labs/windmillhub#189 (`chore(main): release 2.12.0`)
has to merge first, which tags v2.12.0 and triggers the image build that publishes
`ghcr.io/windmill-labs/windmillhub-ee-public:2.12.0`. Merging this before that lands would
point every default hub install at a tag that does not exist yet.

## What the bump carries

2.10.0 → 2.12.0 is two minor releases, so it is not only the database url change. Anyone on
the chart default picks up one migration (`V39__curated_nullable.sql`), plus inline project
item previews, the import wizard's project summaries endpoint, three-state `curated`, and the
documented-integration flag on `/integrations/list`. Operators who would rather move the hub
separately can keep pinning `hub.tag`.

## Changes

- `hub.tag` default 2.10.0 → 2.12.0, with the README values table regenerated to match.
- Chart version 4.0.249 → 4.0.250.

## Test plan

- [x] `helm template` with `hub.enabled=true` renders
      `ghcr.io/windmill-labs/windmillhub-ee-public:2.12.0`, and with `hub.databaseUrlAsFile=true`
      that image is the one receiving `DATABASE_URL_FILE`.
- [x] `helm lint`
- [ ] Cannot pull the image until the release lands; that is the gate above.