### PR TITLE
fix: bump appVersion to 1.798.0 (windmill-extra:1.796.0 was never published)

### DIFF
--- a/charts/windmill/Chart.yaml
+++ b/charts/windmill/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: windmill
 type: application
-version: 4.0.249
-appVersion: 1.796.0
+version: 4.0.250
+appVersion: 1.798.0
 dependencies:
   - condition: minio.enabled
     name: minio


### PR DESCRIPTION
## Problem

Reported by a user, whose `windmill-extra` pod has been failing for over a day:

> container "windmill-extra" in pod "windmill-extra-7bbc68596d-l2fm4" is waiting to start: image can't be pulled

The chart pins every Windmill image to `.Chart.AppVersion`, which was `1.796.0` — and `ghcr.io/windmill-labs/windmill-extra:1.796.0` **was never published**.

| tag | `windmill` | `windmill-ee` | `windmill-extra` |
|---|---|---|---|
| 1.794.0 | ✅ | ✅ | ✅ |
| 1.795.0 | ✅ | ✅ | ❌ |
| **1.796.0** | ✅ | ✅ | **❌** |
| 1.797.0 | ✅ | ✅ | ✅ |
| 1.798.0 | ✅ | ✅ | ✅ |

It's not breaking for existing installs — the old ReplicaSet isn't torn down until the new one is healthy — but it blocks fresh installs and leaves a permanently red pod on upgrades.

## Fix

Bump `appVersion` to `1.798.0`, the newest release where all three AppVersion-pinned images exist.

`1.798.1` is deliberately **not** used: its `windmill-extra` build was still in progress at time of writing.

Verified by rendering all three CI value sets and resolving every resulting image manifest against GHCR:

```
ghcr.io/windmill-labs/windmill:1.798.0        200
ghcr.io/windmill-labs/windmill-ee:1.798.0     200
ghcr.io/windmill-labs/windmill-extra:1.798.0  200
```

## Root cause (upstream, already fixed)

`publish_extra.yml` in `windmill-labs/windmill` gates publishing on a `test_extra` job. That job failed for `v1.794.1`, `v1.795.0` and `v1.796.0` on identical assertions:

```
✗ Debugger TypeScript execution: Missing expected output. Got: ["Preparing dependencies..."]
✗ Debugger breakpoint support: Timeout waiting for event: stopped
```

Bun 1.4 changed the inspector token to a hyphenated UUID; the URL-scraping regex `/ws:\/\/[\d.]+:\d+\/[a-z0-9]+/i` truncated it at the first hyphen, so the attach 404'd and timed out. Fixed by windmill-labs/windmill#10828, which landed in 1.797.0 — hence 1.797.0 and 1.798.0 both publishing cleanly.

## Two things still worth addressing separately

1. **A failed test skips the publish silently.** `publish_extra` is wired with `needs: [sleep, test_extra]`, so a red test marks the publish *skipped*, not failed. The only symptom is an absent tag — nothing alerts, and the helm bump bot points `appVersion` at it regardless. That's what turned a debugger test failure into user-facing `ImagePullBackOff` across three consecutive releases.
2. **`windmill-extra:X.Y.Z` isn't reproducibly tied to its release.** `docker/DockerfileExtra` builds `FROM ghcr.io/windmill-labs/windmill-ee-slim:latest`, so Bun came from an unpinned base — which is why this broke with zero commits touching the debugger.

Worth noting the bump PR that introduced this (#686) had a **failing `lint-test` check** at merge time. CI caught it; it was merged anyway. The check ran before any 1.796.0 image was published, so it failed on *all* images and read as "the bot ran too early" — which was true for two of the three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
